### PR TITLE
Improve SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,26 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>MT academy</title>
+<meta name="description" content="Mock trial practice tools, quizzes, and resources from MT academy help students and coaches sharpen their skills.">
+<meta name="keywords" content="mock trial, mock trial practice, mock trial resources, mock trial quizzes, high school mock trial, mock trial coaching, mock trial competition, MT academy">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://mocktrialacademy.com/">
+<meta property="og:title" content="MT academy">
+<meta property="og:description" content="Mock trial practice tools, quizzes, and resources for students and coaches.">
+<meta property="og:url" content="https://mocktrialacademy.com/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="MT academy">
+<meta property="og:locale" content="en_US">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "MT academy",
+  "url": "https://mocktrialacademy.com/",
+  "description": "Mock trial practice tools, quizzes, and resources for students and coaches.",
+  "keywords": ["mock trial","mock trial practice","mock trial resources","mock trial quizzes","high school mock trial","mock trial coaching","mock trial competition","MT academy"]
+}
+</script>
 <style>
 /* Color palette aligned with logo; emphasize blue */
 :root{--bg:linear-gradient(135deg,#0ea5e9 70%,#fb923c);--card:#e0f2fe;--muted:#6b7280;--text:#0f172a;--accent:#0ea5e9;--secondary:#fb923c}
@@ -82,7 +102,8 @@ a.inline{color:var(--accent);text-decoration:underline}
         <h1 style="margin:0">MT academy
         <span id="modeBadge" class="badge-mode" title="Scoring Engine">Mode: Built-in (less accurate)</span>
       </h1>
-      <div class="small">Objection Practice</div>
+      <div class="small">Mock Trial Objection Practice</div>
+      <p class="small">Mock trial practice tools, rules, and quizzes for students and coaches.</p>
     </div>
     <div id="menuToggle" class="menu-toggle" aria-label="Menu" aria-expanded="false">
       <span></span>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset
-      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
-            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+              http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+  <!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+  <url>
+    <loc>https://mocktrialacademy.com/</loc>
+    <lastmod>2025-08-31T04:08:42+00:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  </urlset>
 
-
-<url>
-  <loc>https://mocktrialacademy.com/</loc>
-  <lastmod>2025-08-31T00:36:38+00:00</lastmod>
-</url>
-
-
-</urlset>


### PR DESCRIPTION
## Summary
- expand meta tags with robots directive, Open Graph details, and JSON-LD structured data for richer mock trial search results
- add mock trial–focused tagline and broader keywords to highlight site purpose
- refresh sitemap with current timestamp and weekly change frequency

## Testing
- `npx --yes htmlhint index.html`
- `xmllint --noout sitemap.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b3c62e63588331bd6a4808d9f9af54