### PR TITLE
Add border outline to app logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
 .app{max-width:1100px;margin:18px auto;padding:16px}
 .header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:12px;position:relative}
 .title-block{flex:1}
-.logo{width:calc(44px*1.25);height:calc(44px*1.25);border-radius:8px;display:flex;align-items:center;justify-content:center;background:linear-gradient(135deg,#0ea5e9 70%,#fb923c);font-weight:700;color:#fff}
+.logo{width:calc(44px*1.25);height:calc(44px*1.25);border-radius:8px;display:flex;align-items:center;justify-content:center;background:linear-gradient(135deg,#0ea5e9 70%,#fb923c);font-weight:700;color:#fff;border:2px solid #000;}
 .nav-menu{position:fixed;top:0;right:0;bottom:0;width:180px;background:var(--card);border-left:1px solid rgba(0,0,0,.1);box-shadow:0 0 8px rgba(0,0,0,.1);display:flex;flex-direction:column;z-index:1000;padding:10px;transform:translateX(100%);transition:transform .3s}
 .nav-menu.open{transform:translateX(0)}
 .nav-menu .tab{background:transparent;border:none;padding:10px 12px;text-align:left;color:var(--text);cursor:pointer}


### PR DESCRIPTION
## Summary
- Add a small black border around the top-left logo for better contrast with the background.

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b4669903948331bf32dbdf0e88259d