### PR TITLE
Add favicon and logo metadata for search results

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0ea5e9"/>
+      <stop offset="1" stop-color="#fb923c"/>
+    </linearGradient>
+  </defs>
+  <rect width="48" height="48" rx="8" fill="url(#g)"/>
+  <text x="24" y="32" font-family="Arial,Helvetica,sans-serif" font-size="24" font-weight="700" fill="#fff" text-anchor="middle">MT</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
 <meta name="keywords" content="mock trial, mock trial practice, mock trial resources, mock trial quizzes, high school mock trial, mock trial coaching, mock trial competition, MT academy">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://mocktrialacademy.com/">
+<link rel="icon" href="/favicon.svg" type="image/svg+xml">
+<link rel="shortcut icon" href="/favicon.svg" type="image/svg+xml">
+<meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
 <meta property="og:title" content="MT academy">
 <meta property="og:description" content="Mock trial practice tools, quizzes, and resources for students and coaches.">
 <meta property="og:url" content="https://mocktrialacademy.com/">
@@ -22,6 +25,15 @@
   "url": "https://mocktrialacademy.com/",
   "description": "Mock trial practice tools, quizzes, and resources for students and coaches.",
   "keywords": ["mock trial","mock trial practice","mock trial resources","mock trial quizzes","high school mock trial","mock trial coaching","mock trial competition","MT academy"]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "url": "https://mocktrialacademy.com/",
+  "name": "MT academy",
+  "logo": "https://mocktrialacademy.com/favicon.svg"
 }
 </script>
 <style>


### PR DESCRIPTION
## Summary
- provide site favicon and open graph image reference
- add Organization structured data for logo
- replace binary favicon with inline SVG asset

## Testing
- `npm test` (fails: ENOENT no package.json)
- `pytest` (no tests discovered)


------
https://chatgpt.com/codex/tasks/task_e_68b4675db6388331a610e0ae99e92126