### PR TITLE
Restore hamburger menu and link section names to pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 .header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:12px;position:relative}
 .title-block{flex:1}
 .logo{width:calc(44px*1.25);height:calc(44px*1.25);border-radius:8px;display:flex;align-items:center;justify-content:center;background:linear-gradient(135deg,#0ea5e9 70%,#fb923c);font-weight:700;color:#fff;border:2px solid #000;}
-.nav-menu{position:fixed;top:0;right:0;bottom:0;width:180px;background:var(--card);border-left:1px solid rgba(0,0,0,.1);box-shadow:0 0 8px rgba(0,0,0,.1);display:none;flex-direction:column;z-index:1000;padding:10px;transform:translateX(100%);transition:transform .3s}
+.nav-menu{position:fixed;top:0;right:0;bottom:0;width:180px;background:var(--card);border-left:1px solid rgba(0,0,0,.1);box-shadow:0 0 8px rgba(0,0,0,.1);display:flex;flex-direction:column;z-index:1000;padding:10px;transform:translateX(100%);transition:transform .3s}
 .nav-menu.open{transform:translateX(0)}
 .nav-menu .tab{background:transparent;border:none;padding:10px 12px;text-align:left;color:var(--text);cursor:pointer}
 .nav-menu .tab.active{background:var(--secondary)}
@@ -60,7 +60,7 @@ section.card{display:none}
 .btn{padding:8px 12px;border-radius:6px;border:1px solid rgba(0,0,0,.1);background:var(--secondary);color:var(--text);cursor:pointer}
 .btn.primary{background:var(--accent);color:#fff}.btn.secondary{background:var(--secondary);color:var(--text)}
 .small{font-size:calc(13px*1.25);color:var(--muted)}
-.menu-toggle{display:none;flex-direction:column;gap:4px;cursor:pointer;padding:8px}
+.menu-toggle{display:flex;flex-direction:column;gap:4px;cursor:pointer;padding:8px}
 .menu-toggle span{display:block;width:24px;height:3px;background:var(--text);border-radius:2px}
 .controls select{font-size:.7em;padding:2px 4px}
 .controls label{font-size:.7em;display:flex;flex-direction:column;align-items:flex-start;gap:2px}
@@ -319,11 +319,11 @@ a.inline{color:var(--accent);text-decoration:underline}
     <h2>How to Use</h2>
     <p class="small">Use the tabs above to explore the different practice tools.</p>
     <ul class="small">
-      <li><a href="#objections" class="hidden-link"><strong>Objections:</strong></a> filter by topic and difficulty, click <em>New Drill</em> for a fresh scenario, pick an objection, then <em>Check</em> or <em>Show Model</em>. Use <em>GPT Prompt</em> or <em>ChatGPT Argue</em> (with text or audio and role selection) to practice with AI; <em>Reset Stats</em> clears progress.</li>
-      <li><a href="#video" class="hidden-link"><strong>Video Coach:</strong></a> choose the speech type, record or <em>Upload Video</em>, then view <em>Metrics</em>, <em>Criteria</em> and the objection finder. Use <em>Re-score</em> or <em>Download</em> as needed. The <em>API Key / Engine</em> option enables ChatGPT-based scoring and testing.</li>
-      <li><a href="#writing" class="hidden-link"><strong>Writing:</strong></a> choose a type, add your notes and goals, then click <em>Ask ChatGPT to Draft</em> to get help writing new material; use <em>API Key / Engine</em> to pick the model.</li>
-      <li><a href="#rules" class="hidden-link"><strong>Rules:</strong></a> search by number or topic, then tap a rule to see the text and a plain-language <em>What it means</em> explanation.</li>
-      <li><a href="#quiz" class="hidden-link"><strong>Rules Quiz:</strong></a> choose mode, rule set, question count and difficulty, then hit <em>Start Quiz</em>. Use <em>Next</em> to advance; the top shows your score and best.</li>
+      <li><a href="objections.html" class="hidden-link"><strong>Objections:</strong></a> filter by topic and difficulty, click <em>New Drill</em> for a fresh scenario, pick an objection, then <em>Check</em> or <em>Show Model</em>. Use <em>GPT Prompt</em> or <em>ChatGPT Argue</em> (with text or audio and role selection) to practice with AI; <em>Reset Stats</em> clears progress.</li>
+      <li><a href="video-coach.html" class="hidden-link"><strong>Video Coach:</strong></a> choose the speech type, record or <em>Upload Video</em>, then view <em>Metrics</em>, <em>Criteria</em> and the objection finder. Use <em>Re-score</em> or <em>Download</em> as needed. The <em>API Key / Engine</em> option enables ChatGPT-based scoring and testing.</li>
+      <li><a href="writing.html" class="hidden-link"><strong>Writing:</strong></a> choose a type, add your notes and goals, then click <em>Ask ChatGPT to Draft</em> to get help writing new material; use <em>API Key / Engine</em> to pick the model.</li>
+      <li><a href="rules.html" class="hidden-link"><strong>Rules:</strong></a> search by number or topic, then tap a rule to see the text and a plain-language <em>What it means</em> explanation.</li>
+      <li><a href="quiz.html" class="hidden-link"><strong>Rules Quiz:</strong></a> choose mode, rule set, question count and difficulty, then hit <em>Start Quiz</em>. Use <em>Next</em> to advance; the top shows your score and best.</li>
     </ul>
     <h3>Upload an API Key</h3>
     <ol class="small" style="margin-top:6px">


### PR DESCRIPTION
## Summary
- Re-enable header hamburger toggle and side navigation menu
- Link "How to Use" section names to their standalone pages with hidden links

## Testing
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b4774d1c80833182583a64d773c5c4