### PR TITLE
Use SVG favicon for search result logo

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -5,6 +5,9 @@
   <meta http-equiv="refresh" content="0; url=/#contact">
   <title>Contact MT academy</title>
   <meta name="description" content="Get in touch with MT academy for support or inquiries.">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  
+  <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
 </head>
 <body>
   <h1>Contact</h1>

--- a/howto.html
+++ b/howto.html
@@ -5,6 +5,9 @@
   <meta http-equiv="refresh" content="0; url=/#howto">
   <title>How to Use MT academy</title>
   <meta name="description" content="Learn how to navigate and use the tools available on MT academy.">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  
+  <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
 </head>
 <body>
   <h1>How to Use</h1>

--- a/index.html
+++ b/index.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>MT academy</title>
 <meta name="description" content="Mock trial practice tools, quizzes, and resources from MT academy help students and coaches sharpen their skills.">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  
 <meta name="keywords" content="mock trial, mock trial practice, mock trial resources, mock trial quizzes, high school mock trial, mock trial coaching, mock trial competition, MT academy">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://mocktrialacademy.com/">
-<link rel="icon" href="/favicon.svg" type="image/svg+xml">
-<link rel="shortcut icon" href="/favicon.svg" type="image/svg+xml">
 <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
 <meta property="og:title" content="MT academy">
 <meta property="og:description" content="Mock trial practice tools, quizzes, and resources for students and coaches.">

--- a/objections.html
+++ b/objections.html
@@ -5,6 +5,9 @@
   <meta http-equiv="refresh" content="0; url=/#objections">
   <title>Objections Drill – MT academy</title>
   <meta name="description" content="Practice mock trial objections with MT academy's interactive drill.">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  
+  <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
 </head>
 <body>
   <h1>Objections Drill</h1>

--- a/quiz.html
+++ b/quiz.html
@@ -5,6 +5,9 @@
   <meta http-equiv="refresh" content="0; url=/#quiz">
   <title>Rules Quiz – MT academy</title>
   <meta name="description" content="Test your knowledge of mock trial rules with MT academy's quiz.">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  
+  <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
 </head>
 <body>
   <h1>Rules Quiz</h1>

--- a/rules.html
+++ b/rules.html
@@ -5,6 +5,9 @@
   <meta http-equiv="refresh" content="0; url=/#rules">
   <title>Rules of Evidence Explorer – MT academy</title>
   <meta name="description" content="Browse the Arizona High School Mock Trial Rules of Evidence with explanations.">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  
+  <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
 </head>
 <body>
   <h1>AZ HS Mock Trial Rules of Evidence</h1>

--- a/video-coach.html
+++ b/video-coach.html
@@ -5,6 +5,9 @@
   <meta http-equiv="refresh" content="0; url=/#video">
   <title>Video Coach – MT academy</title>
   <meta name="description" content="Record, transcribe, and score performances with MT academy's Video Coach.">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  
+  <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
 </head>
 <body>
   <h1>Video Coach</h1>

--- a/writing.html
+++ b/writing.html
@@ -5,6 +5,9 @@
   <meta http-equiv="refresh" content="0; url=/#writing">
   <title>Writing New Materials – MT academy</title>
   <meta name="description" content="Generate mock trial materials and prompts using MT academy's writing tools.">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  
+  <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
 </head>
 <body>
   <h1>Writing New Materials</h1>


### PR DESCRIPTION
## Summary
- Drop binary PNG/ICO assets and serve a single SVG favicon across pages
- Reference the SVG icon in Open Graph metadata and JSON-LD so search results display the logo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b472b97de48331a02104263d0d287a