### PR TITLE
Add Google tag to site pages

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-3QMGWMD9KZ"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-3QMGWMD9KZ');
+  </script>
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=/#contact">
   <title>Contact MT academy</title>

--- a/howto.html
+++ b/howto.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-3QMGWMD9KZ"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-3QMGWMD9KZ');
+  </script>
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=/#howto">
   <title>How to Use MT academy</title>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-3QMGWMD9KZ"></script>
+<script>
+ window.dataLayer = window.dataLayer || [];
+ function gtag(){dataLayer.push(arguments);}
+ gtag('js', new Date());
+ gtag('config', 'G-3QMGWMD9KZ');
+</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>MT academy</title>

--- a/objections.html
+++ b/objections.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-3QMGWMD9KZ"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-3QMGWMD9KZ');
+  </script>
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=/#objections">
   <title>Objections Drill – MT academy</title>

--- a/quiz.html
+++ b/quiz.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-3QMGWMD9KZ"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-3QMGWMD9KZ');
+  </script>
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=/#quiz">
   <title>Rules Quiz – MT academy</title>

--- a/rules.html
+++ b/rules.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-3QMGWMD9KZ"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-3QMGWMD9KZ');
+  </script>
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=/#rules">
   <title>Rules of Evidence Explorer – MT academy</title>

--- a/video-coach.html
+++ b/video-coach.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-3QMGWMD9KZ"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-3QMGWMD9KZ');
+  </script>
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=/#video">
   <title>Video Coach – MT academy</title>

--- a/writing.html
+++ b/writing.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-3QMGWMD9KZ"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-3QMGWMD9KZ');
+  </script>
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=/#writing">
   <title>Writing New Materials – MT academy</title>


### PR DESCRIPTION
## Summary
- add Google Analytics tag after the head on every HTML page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b485fbe6cc8331bbf0cfb20fb72418