### PR TITLE
Improve highlight visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,13 +81,14 @@ textarea{width:100%;min-height:120px;background:var(--card);color:var(--text);bo
 .quiz-q{font-weight:600;margin-bottom:6px}.quiz-opt{display:block;margin:6px 0;padding:6px 8px;border:1px solid rgba(0,0,0,.1);border-radius:6px;background:var(--secondary)}
 .quiz-correct{background:rgba(34,197,94,.15)}.quiz-wrong{background:rgba(239,68,68,.15)}
 /* Transcript highlight classes */
-.hl-leading{background:rgba(79,195,247,.22)}
-.hl-hearsay{background:rgba(16,185,129,.22)}
-.hl-spec{background:rgba(99,102,241,.22)}
-.hl-narr{background:rgba(250,204,21,.22)}
-.hl-arg{background:rgba(239,68,68,.22)}
-.hl-comp{background:rgba(168,85,247,.22)}
-.hl-asked{background:rgba(148,163,184,.22)}
+.hl-leading,.hl-hearsay,.hl-spec,.hl-narr,.hl-arg,.hl-comp,.hl-asked{font-weight:600;padding:0 2px;border-radius:4px}
+.hl-leading{background:rgba(79,195,247,.4)}
+.hl-hearsay{background:rgba(16,185,129,.4)}
+.hl-spec{background:rgba(99,102,241,.4)}
+.hl-narr{background:rgba(250,204,21,.4)}
+.hl-arg{background:rgba(239,68,68,.4)}
+.hl-comp{background:rgba(168,85,247,.4)}
+.hl-asked{background:rgba(148,163,184,.4)}
 .tag{display:inline-block;padding:2px 6px;border-radius:999px;border:1px solid rgba(0,0,0,.14);margin:0 4px 4px 0}
 .table{width:100%;border-collapse:collapse;margin-top:8px}
 .table th,.table td{border:1px solid rgba(0,0,0,.1);padding:6px 8px;text-align:left}


### PR DESCRIPTION
## Summary
- increase opacity and weight of transcript highlights for better readability

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b487842a9883319f85f984e9486459