### PR TITLE
Increase font size for dropdowns and small text

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,11 +67,11 @@ section.card{display:none}
 .controls{display:flex;gap:8px;flex-wrap:wrap;align-items:flex-start;justify-content:flex-start;flex-direction:column}
 .btn{padding:8px 12px;border-radius:6px;border:1px solid rgba(0,0,0,.1);background:var(--secondary);color:var(--text);cursor:pointer}
 .btn.primary{background:var(--accent);color:#fff}.btn.secondary{background:var(--secondary);color:var(--text)}
-.small{font-size:calc(13px*1.25);color:var(--muted)}
+.small{font-size:calc(18px*1.75);color:var(--muted)}
 .menu-toggle{display:flex;flex-direction:column;gap:4px;cursor:pointer;padding:8px}
 .menu-toggle span{display:block;width:24px;height:3px;background:var(--text);border-radius:2px}
-.controls select{font-size:.7em;padding:2px 4px}
-.controls label{font-size:.7em;display:flex;flex-direction:column;align-items:flex-start;gap:2px}
+.controls select{font-size:1.75em;padding:6px 10px}
+.controls label{font-size:1.75em;display:flex;flex-direction:column;align-items:flex-start;gap:2px}
 textarea{width:100%;min-height:120px;background:var(--card);color:var(--text);border-radius:6px;padding:8px;border:1px solid rgba(0,0,0,.1);resize:vertical}
 .fact{background:var(--secondary);padding:10px;border-radius:6px;margin:8px 0}
 .result.ok{border-left:4px solid #16a34a;padding:8px}.result.bad{border-left:4px solid #ef4444;padding:8px}


### PR DESCRIPTION
## Summary
- Raise `.small` font size to a 1.75 scale for clearer tiny words
- Increase dropdown select and label font size to 1.75em for better visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b48a632c7c8331a2e807626d456a9f