### PR TITLE
feat: regenerate sitemap

### DIFF
--- a/generate_sitemap.py
+++ b/generate_sitemap.py
@@ -1,0 +1,56 @@
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+import subprocess
+
+BASE_URL = "https://mocktrialacademy.com"
+
+
+def lastmod_from_git(path: Path) -> datetime:
+    """Return the commit date of the last change to *path*."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%cI", str(path)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        mtime = datetime.fromisoformat(result.stdout.strip())
+        now = datetime.now(timezone.utc)
+        if mtime > now:
+            mtime = now
+        return mtime
+    except Exception:
+        return datetime.now(timezone.utc)
+
+
+def build_urls(root: Path):
+    urls = []
+    for path in root.rglob("*.html"):
+        if path.name.startswith("_"):
+            continue
+        loc = BASE_URL + "/" + path.relative_to(root).as_posix()
+        if path.name == "index.html":
+            loc = BASE_URL + "/"
+        mtime = lastmod_from_git(path)
+        urls.append((loc, mtime))
+    urls.sort(key=lambda x: x[0])
+    return urls
+
+
+def write_sitemap(urls, outfile: Path):
+    with outfile.open("w", encoding="utf-8") as f:
+        f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+        f.write('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n')
+        for loc, mtime in urls:
+            f.write("  <url>\n")
+            f.write(f"    <loc>{loc}</loc>\n")
+            f.write(f"    <lastmod>{mtime.date().isoformat()}</lastmod>\n")
+            f.write("  </url>\n")
+        f.write('</urlset>\n')
+
+
+if __name__ == "__main__":
+    root = Path(__file__).resolve().parent
+    urls = build_urls(root)
+    write_sitemap(urls, root / "sitemap.xml")

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,48 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
-              http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-  <!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mocktrialacademy.com/</loc>
-    <lastmod>2025-08-31T04:08:42+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-  </url>
-  <url>
-    <loc>https://mocktrialacademy.com/objections.html</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://mocktrialacademy.com/video-coach.html</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://mocktrialacademy.com/writing.html</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://mocktrialacademy.com/rules.html</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://mocktrialacademy.com/quiz.html</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://mocktrialacademy.com/howto.html</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <lastmod>2025-08-31</lastmod>
   </url>
   <url>
     <loc>https://mocktrialacademy.com/contact.html</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
+    <lastmod>2025-08-31</lastmod>
+  </url>
+  <url>
+    <loc>https://mocktrialacademy.com/howto.html</loc>
+    <lastmod>2025-08-31</lastmod>
+  </url>
+  <url>
+    <loc>https://mocktrialacademy.com/objections.html</loc>
+    <lastmod>2025-08-31</lastmod>
+  </url>
+  <url>
+    <loc>https://mocktrialacademy.com/quiz.html</loc>
+    <lastmod>2025-08-31</lastmod>
+  </url>
+  <url>
+    <loc>https://mocktrialacademy.com/rules.html</loc>
+    <lastmod>2025-08-31</lastmod>
+  </url>
+  <url>
+    <loc>https://mocktrialacademy.com/video-coach.html</loc>
+    <lastmod>2025-08-31</lastmod>
+  </url>
+  <url>
+    <loc>https://mocktrialacademy.com/writing.html</loc>
+    <lastmod>2025-08-31</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add Python script to generate sitemap from repo HTML files using git commit timestamps
- regenerate sitemap.xml to include all pages with updated lastmod dates

## Testing
- `python generate_sitemap.py`
- `xmllint --noout sitemap.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b48f2d922c8331933312adf41ce523