### PR TITLE
Restore normal font sizes

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,11 +67,11 @@ section.card{display:none}
 .controls{display:flex;gap:8px;flex-wrap:wrap;align-items:flex-start;justify-content:flex-start;flex-direction:column}
 .btn{padding:8px 12px;border-radius:6px;border:1px solid rgba(0,0,0,.1);background:var(--secondary);color:var(--text);cursor:pointer}
 .btn.primary{background:var(--accent);color:#fff}.btn.secondary{background:var(--secondary);color:var(--text)}
-.small{font-size:calc(18px*.5);color:var(--muted)}
+.small{font-size:1em;color:var(--muted)}
 .menu-toggle{display:flex;flex-direction:column;gap:4px;cursor:pointer;padding:8px}
 .menu-toggle span{display:block;width:24px;height:3px;background:var(--text);border-radius:2px}
-.controls select{font-size:.5em;padding:6px 10px}
-.controls label{font-size:.5em;display:flex;flex-direction:column;align-items:flex-start;gap:2px}
+.controls select{font-size:1em;padding:6px 10px}
+.controls label{font-size:1em;display:flex;flex-direction:column;align-items:flex-start;gap:2px}
 textarea{width:100%;min-height:120px;background:var(--card);color:var(--text);border-radius:6px;padding:8px;border:1px solid rgba(0,0,0,.1);resize:vertical}
 .fact{background:var(--secondary);padding:10px;border-radius:6px;margin:8px 0}
 .result.ok{border-left:4px solid #16a34a;padding:8px}.result.bad{border-left:4px solid #ef4444;padding:8px}


### PR DESCRIPTION
## Summary
- Restore body font size and dropdown elements to default scale for readability
- Remove reduced `.small` text sizing for consistent typography

## Testing
- `python -m py_compile generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68b491b58aa883319965f49c4d48e7da