### PR TITLE
Normalize font sizes

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
 @media (prefers-color-scheme: dark){
   :root{--bg:#0f172a;--card:#1e293b;--muted:#94a3b8;--text:#f8fafc;--accent:#3b82f6;--secondary:#f59e0b}
 }
-*{box-sizing:border-box}body{margin:0;font-size:110%;font-family:Inter,system-ui,Segoe UI,Roboto,Arial;background:var(--bg);color:var(--text);min-height:100vh;border:12px solid transparent;border-image:linear-gradient(135deg,#3b82f6,#f59e0b) 1}
+*{box-sizing:border-box}body{margin:0;font-size:100%;font-family:Inter,system-ui,Segoe UI,Roboto,Arial;background:var(--bg);color:var(--text);min-height:100vh;border:12px solid transparent;border-image:linear-gradient(135deg,#3b82f6,#f59e0b) 1}
 .app{max-width:1100px;margin:18px auto;padding:16px}
 .header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:12px;position:relative}
 .title-block{flex:1}
@@ -67,17 +67,17 @@ section.card{display:none}
 .controls{display:flex;gap:8px;flex-wrap:wrap;align-items:flex-start;justify-content:flex-start;flex-direction:column}
 .btn{padding:8px 12px;border-radius:6px;border:1px solid rgba(0,0,0,.1);background:var(--secondary);color:var(--text);cursor:pointer}
 .btn.primary{background:var(--accent);color:#fff}.btn.secondary{background:var(--secondary);color:var(--text)}
-.small{font-size:calc(18px*.5);color:var(--muted)}
+.small{font-size:1em;color:var(--muted)}
 .menu-toggle{display:flex;flex-direction:column;gap:4px;cursor:pointer;padding:8px}
 .menu-toggle span{display:block;width:24px;height:3px;background:var(--text);border-radius:2px}
-.controls select{font-size:.35em;padding:4px 8px}
-.controls label{font-size:.35em;display:flex;flex-direction:column;align-items:flex-start;gap:2px}
+.controls select{font-size:1em;padding:4px 8px}
+.controls label{font-size:1em;display:flex;flex-direction:column;align-items:flex-start;gap:2px}
 textarea{width:100%;min-height:120px;background:var(--card);color:var(--text);border-radius:6px;padding:8px;border:1px solid rgba(0,0,0,.1);resize:vertical}
 .fact{background:var(--secondary);padding:10px;border-radius:6px;margin:8px 0}
 .result.ok{border-left:4px solid #16a34a;padding:8px}.result.bad{border-left:4px solid #ef4444;padding:8px}
 .rule-item{border:1px solid rgba(0,0,0,.1);border-radius:8px;padding:10px;margin:6px 0}
 .rule-title{font-weight:600;cursor:pointer}
-.badge{font-size:calc(11px*1.25);padding:2px 6px;border-radius:999px;background:var(--accent);color:#fff}
+.badge{font-size:1em;padding:2px 6px;border-radius:999px;background:var(--accent);color:#fff}
 .quiz-q{font-weight:600;margin-bottom:6px}.quiz-opt{display:block;margin:6px 0;padding:6px 8px;border:1px solid rgba(0,0,0,.1);border-radius:6px;background:var(--secondary)}
 .quiz-correct{background:rgba(34,197,94,.15)}.quiz-wrong{background:rgba(239,68,68,.15)}
 /* Transcript highlight classes */
@@ -100,14 +100,14 @@ textarea{width:100%;min-height:120px;background:var(--card);color:var(--text);bo
 .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.4);display:none;align-items:center;justify-content:center;z-index:9999}
 .modal{width:min(740px,94vw);background:var(--card);border:1px solid rgba(0,0,0,.1);border-radius:12px;box-shadow:0 10px 30px rgba(0,0,0,.2);padding:16px}
 .modal h2{margin:0 0 6px}
-.modal .note{font-size:calc(13px*1.25);color:var(--muted);margin-bottom:10px}
+.modal .note{font-size:1em;color:var(--muted);margin-bottom:10px}
 .input{width:100%;padding:10px;border-radius:8px;border:1px solid rgba(0,0,0,.1);background:var(--secondary);color:var(--text)}
 .row{display:flex;gap:10px;flex-wrap:wrap}
 .choice{flex:1;border:1px solid rgba(0,0,0,.1);border-radius:10px;padding:12px;background:var(--secondary)}
 .choice h3{margin:0 0 6px}
-.warn{background:#fef2f2;color:#991b1b;border:1px solid #fca5a5;padding:6px 8px;border-radius:8px;font-size:calc(12px*1.25)}
+.warn{background:#fef2f2;color:#991b1b;border:1px solid #fca5a5;padding:6px 8px;border-radius:8px;font-size:1em}
 .ok{background:#f0fdf4;color:#166534;border:1px solid #6ee7b7;padding:6px 8px;border-radius:8px}
-.badge-mode{font-size:calc(12px*1.25);padding:2px 6px;border-radius:999px;background:var(--secondary);color:var(--text);margin-left:6px}
+.badge-mode{font-size:1em;padding:2px 6px;border-radius:999px;background:var(--secondary);color:var(--text);margin-left:6px}
 .chat-entry{margin-top:8px;padding:6px;border-radius:6px;border:1px solid rgba(0,0,0,.1)}
 .chat-entry.user{background:var(--secondary)}
 .chat-entry.chatgpt{background:var(--accent);color:#fff}


### PR DESCRIPTION
## Summary
- Reset body text to default size and unified component font sizing to 1em.

## Testing
- `python -m py_compile generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4948d0e1883319d9ca4238de3d469