### PR TITLE
Reduce mode badge size and show only when needed

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@ textarea{width:100%;min-height:120px;background:var(--card);color:var(--text);bo
 .choice h3{margin:0 0 6px}
 .warn{background:#fef2f2;color:#991b1b;border:1px solid #fca5a5;padding:6px 8px;border-radius:8px;font-size:1em}
 .ok{background:#f0fdf4;color:#166534;border:1px solid #6ee7b7;padding:6px 8px;border-radius:8px}
-.badge-mode{font-size:1em;padding:2px 6px;border-radius:999px;background:var(--secondary);color:var(--text);margin-left:6px}
+.badge-mode{font-size:0.6em;padding:1px 4px;border-radius:999px;background:var(--secondary);color:var(--text);margin-left:6px}
 .chat-entry{margin-top:8px;padding:6px;border-radius:6px;border:1px solid rgba(0,0,0,.1)}
 .chat-entry.user{background:var(--secondary)}
 .chat-entry.chatgpt{background:var(--accent);color:#fff}
@@ -123,7 +123,7 @@ a.inline{color:var(--accent);text-decoration:underline}
     <div class="logo">MT</div>
     <div class="title-block">
         <h1 style="margin:0">MT academy
-        <span id="modeBadge" class="badge-mode" title="Scoring Engine">Mode: Built-in (less accurate)</span>
+        <span id="modeBadge" class="badge-mode" title="Scoring Engine" style="display:none">Mode: Built-in (less accurate)</span>
       </h1>
       <div class="small">Mock Trial Objection Practice</div>
       <p class="small">Interactive mock trial practice tools, objection drills, rule explanations, and quizzes to help students and coaches sharpen courtroom skills.</p>
@@ -2426,6 +2426,12 @@ document.addEventListener('DOMContentLoaded',()=>{
         else{link.classList.remove('active');}
       });
       location.hash=id;
+      const usesMode = id==='objections' || id==='video' || id==='writing';
+      const badge=$('modeBadge');
+      if(badge){
+        badge.style.display = usesMode ? 'inline-block' : 'none';
+        if(usesMode) renderModeBadge();
+      }
       if(id==='video'){ maybeShowVideoGate(); }
     }
 


### PR DESCRIPTION
## Summary
- shrink the top Mode badge by reducing its font and padding
- show the Mode badge only on sections that use the scoring engine

## Testing
- `python -m py_compile generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68b49667750c8331b838e29ee8b87ddd