### PR TITLE
Add posture scoring to video coach

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@ a.inline{color:var(--accent);text-decoration:underline}
       <button id="btnShowCriteria" class="btn secondary">Show Criteria</button>
       <button id="btnChangeEngine" class="btn secondary" title="Switch scoring engine or update API key">API Key / Engine</button>
       <button id="btnTestChatGPT" class="btn secondary" title="Send a tiny test to ChatGPT">Test ChatGPT</button>
-      <button id="btnRatePosture" class="btn secondary">Rate Posture</button>
+      <button id="btnRatePosture" class="btn secondary">Rate Body Language</button>
     </div>
     <div id="videoFeedback" class="small"></div>
     <div id="videoRubricDetails" class="small" style="display:none"></div>
@@ -1760,8 +1760,10 @@ const VideoCoach=(function(){
     const comments=result.comments||{};
     const hasComments=Object.keys(comments).length>0;
     const rows=conf.cats.map(c=>`<tr><td>${c.n}</td><td style="width:220px">${scorebar(pack[c.key])}</td>${hasComments?`<td>${escHTML(comments[c.key]||'')}</td>`:''}</tr>`).join('');
-    const finalLabel=result.postureScore!=null?'Final Score (with posture)':'Final Score';
+    const finalLabel=result.postureScore!=null?'Final Score (with body language)':'Final Score';
     const postureRow=result.postureScore!=null?`<div>Posture Score</div><div>${result.postureScore.toFixed(1)}/10</div>`:'';
+    const gestureRow=result.gestureScore!=null?`<div>Gesture Score</div><div>${result.gestureScore.toFixed(1)}/10</div>`:'';
+    const movementRow=result.movementScore!=null?`<div>Movement Score</div><div>${result.movementScore.toFixed(1)}/10</div>`:'';
     $('videoFeedback').innerHTML=`
       <div><strong>${conf.name} \u2014 Judge Rubric Report</strong></div>
       <table class="table"><thead><tr><th>Category</th><th>Score</th>${hasComments?'<th>Comment</th>':''}</tr></thead><tbody>${rows}</tbody></table>
@@ -1775,6 +1777,8 @@ const VideoCoach=(function(){
         <div>Exemplar Similarity (lex)</div><div>${Math.round(cmp.lexCos*100)}%</div>
         <div>Exemplar Similarity (bigrams)</div><div>${Math.round(cmp.biCos*100)}%</div>
         ${postureRow}
+        ${gestureRow}
+        ${movementRow}
       </div>`;
     if(result.explanation){
       $('videoFeedback').innerHTML += `<div class="small" style="margin-top:8px"><strong>Explanation:</strong> ${escHTML(result.explanation)}</div>`;
@@ -1783,7 +1787,7 @@ const VideoCoach=(function(){
       $('videoFeedback').innerHTML += `<div class="small" style="margin-top:4px"><strong>Notes:</strong> ${escHTML(result.notes)}</div>`;
     }
     if(result.postureAdvice){
-      $('videoFeedback').innerHTML += `<div class="small" style="margin-top:4px"><strong>Posture Tips:</strong> ${escHTML(result.postureAdvice)}</div>`;
+      $('videoFeedback').innerHTML += `<div class="small" style="margin-top:4px"><strong>Body Tips:</strong> ${escHTML(result.postureAdvice)}</div>`;
     }
     $('videoFeedback').innerHTML += `
       <div style="margin-top:6px">
@@ -1996,7 +2000,9 @@ const VideoCoach=(function(){
       result.total=Math.min(100,result.total+7);
     }
     if(postureRes){
-      result.postureScore=postureRes.score;
+      result.postureScore=postureRes.posture;
+      result.gestureScore=postureRes.gesture;
+      result.movementScore=postureRes.movement;
       result.postureAdvice=postureRes.advice;
       result.total=Math.round(result.total*(1-POSTURE_WEIGHT)+postureRes.score*10*POSTURE_WEIGHT);
     }
@@ -2037,7 +2043,9 @@ const VideoCoach=(function(){
         }
         result.total=Math.round(conf.cats.reduce((sum,c)=>sum+clamp(result.cats[c.key],1,10)*(c.w*10),0));
         if(postureRes){
-          result.postureScore=postureRes.score;
+          result.postureScore=postureRes.posture;
+          result.gestureScore=postureRes.gesture;
+          result.movementScore=postureRes.movement;
           result.postureAdvice=postureRes.advice;
           result.total=Math.round(result.total*(1-POSTURE_WEIGHT)+postureRes.score*10*POSTURE_WEIGHT);
         }
@@ -2068,7 +2076,7 @@ const VideoCoach=(function(){
   async function ratePosture(){
     if(!lastVideoBlob){ alert('Please record or upload a video first.'); return; }
     $('videoFeedback').innerHTML='';
-    $('videoStatus').textContent='Analyzing posture…';
+    $('videoStatus').textContent='Analyzing body language…';
     try{
       const transcript=$('videoTranscript').value||'';
       const res=await Posture.score(lastVideoBlob);
@@ -2077,7 +2085,7 @@ const VideoCoach=(function(){
         try{
           const msgs=[
             {role:'system',content:'You are a helpful posture coach.'},
-            {role:'user',content:`Transcript: "${transcript}"\nPosture score: ${res.score}. Give concise posture improvement tips.`}
+            {role:'user',content:`Transcript: "${transcript}"\nPosture score: ${res.posture}/10\nGesture score: ${res.gesture}/10\nMovement score: ${res.movement}/10\nGive concise body language improvement tips.`}
           ];
           const resp=await fetch('https://api.openai.com/v1/chat/completions',{
             method:'POST',
@@ -2089,10 +2097,10 @@ const VideoCoach=(function(){
           if(text) tips=text;
         }catch(e){}
       }
-      $('videoFeedback').innerHTML=`<div class="small"><strong>Posture Score:</strong> ${res.score}/10</div><div class="small" style="margin-top:4px"><strong>Posture Tips:</strong> ${escHTML(tips)}</div>`;
-      $('videoStatus').textContent='Posture scored.';
+      $('videoFeedback').innerHTML=`<div class="kv small"><div>Final Body Score</div><div>${res.score}/10</div><div>Posture</div><div>${res.posture}/10</div><div>Gesture</div><div>${res.gesture}/10</div><div>Movement</div><div>${res.movement}/10</div></div><div class="small" style="margin-top:4px"><strong>Body Tips:</strong> ${escHTML(tips)}</div>`;
+      $('videoStatus').textContent='Body language scored.';
     }catch(e){
-      $('videoStatus').textContent='Posture analysis failed.';
+      $('videoStatus').textContent='Body analysis failed.';
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -267,6 +267,7 @@ a.inline{color:var(--accent);text-decoration:underline}
       <button id="btnShowCriteria" class="btn secondary">Show Criteria</button>
       <button id="btnChangeEngine" class="btn secondary" title="Switch scoring engine or update API key">API Key / Engine</button>
       <button id="btnTestChatGPT" class="btn secondary" title="Send a tiny test to ChatGPT">Test ChatGPT</button>
+      <button id="btnRatePosture" class="btn secondary">Rate Posture</button>
     </div>
     <div id="videoFeedback" class="small"></div>
     <div id="videoRubricDetails" class="small" style="display:none"></div>
@@ -2064,6 +2065,37 @@ const VideoCoach=(function(){
     showProvenance('Built-in score used (ChatGPT mode not active).', true);
   }
 
+  async function ratePosture(){
+    if(!lastVideoBlob){ alert('Please record or upload a video first.'); return; }
+    $('videoFeedback').innerHTML='';
+    $('videoStatus').textContent='Analyzing posture…';
+    try{
+      const transcript=$('videoTranscript').value||'';
+      const res=await Posture.score(lastVideoBlob);
+      let tips=res.advice;
+      if(EngineState.mode==='chatgpt' && EngineState.openaiKey){
+        try{
+          const msgs=[
+            {role:'system',content:'You are a helpful posture coach.'},
+            {role:'user',content:`Transcript: "${transcript}"\nPosture score: ${res.score}. Give concise posture improvement tips.`}
+          ];
+          const resp=await fetch('https://api.openai.com/v1/chat/completions',{
+            method:'POST',
+            headers:{'Content-Type':'application/json','Authorization':`Bearer ${EngineState.openaiKey}`},
+            body:JSON.stringify({model:EngineState.openaiModel||'gpt-4o-mini',messages:msgs,max_tokens:120,temperature:0.7})
+          });
+          const data=await resp.json();
+          const text=data?.choices?.[0]?.message?.content?.trim();
+          if(text) tips=text;
+        }catch(e){}
+      }
+      $('videoFeedback').innerHTML=`<div class="small"><strong>Posture Score:</strong> ${res.score}/10</div><div class="small" style="margin-top:4px"><strong>Posture Tips:</strong> ${escHTML(tips)}</div>`;
+      $('videoStatus').textContent='Posture scored.';
+    }catch(e){
+      $('videoStatus').textContent='Posture analysis failed.';
+    }
+  }
+
   function crit(type){
     const conf=RUBRICS[type]||RUBRICS.opening;
     $('videoCriteria').innerHTML=`<strong>${conf.name} \u2014 Criteria</strong><ul style="margin:6px 0 0 18px">${conf.cats.map(c=>`<li><strong>${c.n}</strong> (weight ${(c.w*100).toFixed(0)}%)</li>`).join('')}</ul>
@@ -2138,6 +2170,7 @@ const VideoCoach=(function(){
     $('btnStopRecording').disabled=true;
     $('btnChangeEngine').addEventListener('click', openVideoGate);
     $('btnTestChatGPT').addEventListener('click', testChatGPT);
+    $('btnRatePosture').addEventListener('click', ratePosture);
     $('btnGPTWrite').addEventListener('click', gptWrite);
     $('btnWriteChangeEngine')?.addEventListener('click', openVideoGate);
     renderModeBadge();

--- a/index.html
+++ b/index.html
@@ -627,10 +627,12 @@ const MT_SCORING = (() => {
     evaluateOpening: responses => evaluate(responses, OPENING_CRITERIA),
     evaluateDirect: responses => evaluate(responses, DIRECT_CRITERIA),
     evaluateCross: responses => evaluate(responses, CROSS_CRITERIA),
-    evaluateClosing: responses => evaluate(responses, CLOSING_CRITERIA),
+  evaluateClosing: responses => evaluate(responses, CLOSING_CRITERIA),
   };
 })();
 </script>
+<script src="https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5/pose.min.js"></script>
+<script src="posture.js"></script>
 <script>
 // ChatGPT scoring and transcript formatting utilities ported from Python
 const ChatGPTScoring = (() => {
@@ -1465,7 +1467,7 @@ function wire(){populate();$('btnNewObj').addEventListener('click',newQ);$('btnC
 
 /* Video Coach (ChatGPT integration + fallback) */
 const VideoCoach=(function(){
-  let stream=null,rec=null,chunks=[],timer=null,sec=0,recog=null, micOnly=false, uploaded=false, uploadedURL=null;
+  let stream=null,rec=null,chunks=[],timer=null,sec=0,recog=null, micOnly=false, uploaded=false, uploadedURL=null, lastVideoBlob=null;
 
   const EXEMPLARS={
     opening:{title:"Opening Exemplar",text:`Theme: choices have consequences. Today, the evidence will show that on June 12th,
@@ -1507,6 +1509,8 @@ const VideoCoach=(function(){
     {name:"Compound", rule:"611(a)", cls:"hl-comp", when:(s)=>/\?[^?]+\?/.test(s)||/\b(and|or)\b.*\?/i.test(s)},
     {name:"Asked & Answered", rule:"611(a)", cls:"hl-asked", when:(s,ctx)=>{ const key=s.toLowerCase().replace(/[^a-z ]/g,'').split(' ').slice(0,8).join(' '); if(ctx.qSeen.has(key)) return true; ctx.qSeen.add(key); return false; }}
   ];
+
+  const POSTURE_WEIGHT=0.3;
 
   function clean(s){return (s||'').toLowerCase().replace(/[^a-z0-9\s']/g,' ').replace(/\s+/g,' ').trim()}
   // Safer sentence split (no lookbehind): convert punctuation to breaks
@@ -1755,11 +1759,13 @@ const VideoCoach=(function(){
     const comments=result.comments||{};
     const hasComments=Object.keys(comments).length>0;
     const rows=conf.cats.map(c=>`<tr><td>${c.n}</td><td style="width:220px">${scorebar(pack[c.key])}</td>${hasComments?`<td>${escHTML(comments[c.key]||'')}</td>`:''}</tr>`).join('');
+    const finalLabel=result.postureScore!=null?'Final Score (with posture)':'Final Score';
+    const postureRow=result.postureScore!=null?`<div>Posture Score</div><div>${result.postureScore.toFixed(1)}/10</div>`:'';
     $('videoFeedback').innerHTML=`
       <div><strong>${conf.name} \u2014 Judge Rubric Report</strong></div>
       <table class="table"><thead><tr><th>Category</th><th>Score</th>${hasComments?'<th>Comment</th>':''}</tr></thead><tbody>${rows}</tbody></table>
       <div class="kv" style="margin-top:8px">
-        <div>Final Score</div><div><strong>${result.total}</strong> / 100</div>
+        <div>${finalLabel}</div><div><strong>${result.total}</strong> / 100</div>
         <div>Words</div><div>${m.wordCount}</div>
         <div>WPM</div><div>${m.wpm||'N/A'}</div>
         <div>Fillers</div><div>${m.fillers}</div>
@@ -1767,12 +1773,16 @@ const VideoCoach=(function(){
         <div>Vocab Richness</div><div>${m.vocabRich.toFixed(1)}/10</div>
         <div>Exemplar Similarity (lex)</div><div>${Math.round(cmp.lexCos*100)}%</div>
         <div>Exemplar Similarity (bigrams)</div><div>${Math.round(cmp.biCos*100)}%</div>
+        ${postureRow}
       </div>`;
     if(result.explanation){
       $('videoFeedback').innerHTML += `<div class="small" style="margin-top:8px"><strong>Explanation:</strong> ${escHTML(result.explanation)}</div>`;
     }
     if(result.notes){
       $('videoFeedback').innerHTML += `<div class="small" style="margin-top:4px"><strong>Notes:</strong> ${escHTML(result.notes)}</div>`;
+    }
+    if(result.postureAdvice){
+      $('videoFeedback').innerHTML += `<div class="small" style="margin-top:4px"><strong>Posture Tips:</strong> ${escHTML(result.postureAdvice)}</div>`;
     }
     $('videoFeedback').innerHTML += `
       <div style="margin-top:6px">
@@ -1819,12 +1829,22 @@ const VideoCoach=(function(){
   function tUpd(){ $('videoTimer').textContent=new Date(sec*1000).toISOString().substr(14,5)}
 
   async function startCamera(){
-    micOnly=false; uploaded=false; setStatus('Requesting camera/mic\u2026');
+    micOnly=false; uploaded=false; lastVideoBlob=null; setStatus('Requesting camera/mic\u2026');
     if(!navigator.mediaDevices||!navigator.mediaDevices.getUserMedia){ setStatus('Camera API not available in this environment. Use Mic Only or Upload Video.',true); return; }
     try{ stream=await navigator.mediaDevices.getUserMedia({video:true,audio:true}); $('videoPreview').srcObject=stream; $('videoPreview').muted=true; await $('videoPreview').play(); }
     catch(e){ setStatus('Camera/mic error: '+e.message+'. Try Mic Only or Upload Video.', true); return; }
     chunks=[]; try{ rec=new MediaRecorder(stream); }catch(e){ setStatus('MediaRecorder not supported: '+e.message+'. You can still use Mic Only.', true); rec=null; }
-    if(rec){ rec.ondataavailable=e=>{ if(e.data&&e.data.size) chunks.push(e.data) }; rec.onstop=()=>{ const blob=new Blob(chunks,{type:'video/webm'}); const url=URL.createObjectURL(blob); $('btnDownloadRecording').href=url; $('btnPlayRecording').onclick=()=>{ const v=$('videoPreview'); v.srcObject=null; v.src=url; v.controls=true; v.play(); }; }; rec.start(); }
+    if(rec){
+      rec.ondataavailable=e=>{ if(e.data&&e.data.size) chunks.push(e.data) };
+      rec.onstop=()=>{
+        const blob=new Blob(chunks,{type:'video/webm'});
+        lastVideoBlob=blob;
+        const url=URL.createObjectURL(blob);
+        $('btnDownloadRecording').href=url;
+        $('btnPlayRecording').onclick=()=>{ const v=$('videoPreview'); v.srcObject=null; v.src=url; v.controls=true; v.play(); };
+      };
+      rec.start();
+    }
     sec=0; tUpd(); if(timer) clearInterval(timer); timer=setInterval(()=>{sec++;tUpd()},1000);
     $('btnVideoStart').disabled=true; $('btnStopRecording').disabled=false; setStatus('Recording\u2026');
     try{
@@ -1837,7 +1857,7 @@ const VideoCoach=(function(){
   }
 
   async function startMicOnly(){
-    micOnly=true; uploaded=false; setStatus('Mic-only transcription\u2026');
+    micOnly=true; uploaded=false; lastVideoBlob=null; setStatus('Mic-only transcription\u2026');
     sec=0; tUpd(); if(timer) clearInterval(timer); timer=setInterval(()=>{sec++;tUpd()},1000);
     $('btnVideoStart').disabled=true; $('btnStopRecording').disabled=false;
     try{
@@ -1850,7 +1870,7 @@ const VideoCoach=(function(){
   }
 
   function handleUpload(file){
-    if(!file) return; uploaded=true; micOnly=false;
+    if(!file) return; uploaded=true; micOnly=false; lastVideoBlob=file;
     if(uploadedURL){ URL.revokeObjectURL(uploadedURL); uploadedURL=null; }
     uploadedURL=URL.createObjectURL(file);
     const v=$('videoPreview'); v.srcObject=null; v.src=uploadedURL; v.controls=true; v.play();
@@ -1962,7 +1982,7 @@ const VideoCoach=(function(){
     }
   }
 
-  function scoreWithBuiltin(type, txt){
+  async function scoreWithBuiltin(type, txt, postureRes){
     const transcript=(type==='direct'||type==='cross')?formatTranscriptQA(txt):txt;
     const det=detectObjections(type,transcript);
     const engine=score(type,transcript);
@@ -1974,75 +1994,73 @@ const VideoCoach=(function(){
     }else if(wpm>=100&&wpm<=115){
       result.total=Math.min(100,result.total+7);
     }
+    if(postureRes){
+      result.postureScore=postureRes.score;
+      result.postureAdvice=postureRes.advice;
+      result.total=Math.round(result.total*(1-POSTURE_WEIGHT)+postureRes.score*10*POSTURE_WEIGHT);
+    }
     renderReport(type,result,det);
     highlightTranscriptArea(type,det);
   }
 
-  function scoreNow(){
+  async function scoreNow(){
     const type=$('videoType').value||'opening';
     const raw=$('videoTranscript').value||'';
     const transcript=(type==='direct'||type==='cross')?formatTranscriptQA(raw):raw;
+    const postureRes=lastVideoBlob&&window.Posture?await Posture.score(lastVideoBlob):null;
 
     if(EngineState.mode==='chatgpt' && EngineState.openaiKey){
       $('videoStatus').textContent='Scoring via ChatGPT\u2026';
-        scoreViaChatGPT(type, transcript).then(parsed=>{
-          const det=detectObjections(type,transcript);
-          const m = baseMetrics(transcript);
-          const result = {
-            cats: parsed.categories || {},
-            comments: parsed.comments || {},
-            total: Math.max(0, Math.min(100, parseInt(parsed.total||0,10))),
-            explanation: parsed.explanation || '',
-            notes: parsed.notes || '',
-            qa: parsed.qa || [],
-            metrics: m,
-          compare: {lexCos:0,biCos:0,mustHits:0,niceHits:0,mustTotal:0,niceTotal:0,struct:0,score:0},
-          qm: {qCount:0,qPerMin:0,avgTokens:0,openCount:0,leadCount:0,compoundCount:0,foundationCount:0,impeachCount:0,followupCount:0,openRatio:0,leadRatio:0,compoundRate:0},
-          effWords: transcript.trim().split(/\s+/).length
+      try{
+        const parsed=await scoreViaChatGPT(type,transcript);
+        const det=detectObjections(type,transcript);
+        const m=baseMetrics(transcript);
+        const result={
+          cats:parsed.categories||{},
+          comments:parsed.comments||{},
+          total:Math.max(0,Math.min(100,parseInt(parsed.total||0,10))),
+          explanation:parsed.explanation||'',
+          notes:parsed.notes||'',
+          qa:parsed.qa||[],
+          metrics:m,
+          compare:{lexCos:0,biCos:0,mustHits:0,niceHits:0,mustTotal:0,niceTotal:0,struct:0,score:0},
+          qm:{qCount:0,qPerMin:0,avgTokens:0,openCount:0,leadCount:0,compoundCount:0,foundationCount:0,impeachCount:0,followupCount:0,openRatio:0,leadRatio:0,compoundRate:0},
+          effWords:transcript.trim().split(/\s+/).length
         };
-        const conf = RUBRICS[type];
-        conf.cats.forEach(c=>{ if(typeof result.cats[c.key] !== 'number'){ result.cats[c.key] = 6; } });
-        if ((type==='opening'||type==='closing') && result.effWords<200) {
-          conf.cats.forEach(c=>{ result.cats[c.key] = clamp(result.cats[c.key]-1,1,10); });
-        } else if (type==='opening' && result.effWords>=300 && result.effWords<=600) {
-          conf.cats.forEach(c=>{ result.cats[c.key] = clamp(result.cats[c.key]+1,1,10); });
+        const conf=RUBRICS[type];
+        conf.cats.forEach(c=>{ if(typeof result.cats[c.key] !== 'number'){ result.cats[c.key]=6; } });
+        if((type==='opening'||type==='closing')&&result.effWords<200){
+          conf.cats.forEach(c=>{ result.cats[c.key]=clamp(result.cats[c.key]-1,1,10); });
+        } else if(type==='opening'&&result.effWords>=300&&result.effWords<=600){
+          conf.cats.forEach(c=>{ result.cats[c.key]=clamp(result.cats[c.key]+1,1,10); });
         }
-        result.total = Math.round(conf.cats.reduce((sum,c)=>sum + clamp(result.cats[c.key],1,10)*(c.w*10),0));
-        const wpm=m.wpm||0;
-        if(wpm<95||wpm>125){
-          result.total=Math.max(0,result.total-10);
-        }else if(wpm>=100&&wpm<=115){
-          result.total=Math.min(100,result.total+7);
+        result.total=Math.round(conf.cats.reduce((sum,c)=>sum+clamp(result.cats[c.key],1,10)*(c.w*10),0));
+        if(postureRes){
+          result.postureScore=postureRes.score;
+          result.postureAdvice=postureRes.advice;
+          result.total=Math.round(result.total*(1-POSTURE_WEIGHT)+postureRes.score*10*POSTURE_WEIGHT);
         }
-        renderReport(type, result, det);
-        highlightTranscriptArea(type, det);
-        $('videoStatus').textContent = 'Scored with ChatGPT.';
+        renderReport(type,result,det);
+        highlightTranscriptArea(type,det);
+        $('videoStatus').textContent='Scored with ChatGPT.';
         showProvenance('Scored by ChatGPT (OpenAI API).');
-      }).catch(err=>{
+      }catch(err){
         let msg='ChatGPT scoring temporarily unavailable \u2014 using built-in for this score only.';
         if(err?.code===429){ msg='Rate limit on your ChatGPT account \u2014 used built-in for this run. Try again shortly.'; }
         else if(err?.message==='unauthorized' || err?.code===401){ msg='Your OpenAI API key is invalid/expired. Update it in \u201cChange Scoring Engine\u201d. Used built-in for this run.'; }
         else if(err?.code==='insufficient_quota'){ msg='Your OpenAI quota is exhausted. Update billing or switch model. Used built-in for this run.'; }
         else if(err?.message==='timeout'){ msg='ChatGPT timed out. Used built-in for this run.'; }
         else if(err?.message==='bad_json'){ msg='ChatGPT returned malformed JSON. Used built-in for this run (your default remains ChatGPT).'; }
-        $('videoStatus').textContent = msg;
-
-        // IMPORTANT: Do NOT flip EngineState.mode
-        scoreWithBuiltin(type, raw);
+        $('videoStatus').textContent=msg;
+        await scoreWithBuiltin(type,raw,postureRes);
         showProvenance('Built-in score used (ChatGPT not reached).', true);
-
-        const badge = $('modeBadge');
-        const banner = $('videoModeBanner');
-        if(badge && /ChatGPT/i.test(badge.textContent)){
-          badge.textContent = 'Mode: ChatGPT (temporary built-in fallback used)';
-        }
-        if(banner && /ChatGPT/i.test(banner.innerHTML)){
-          banner.innerHTML = 'Scoring via <strong>built-in heuristic engine</strong> (ChatGPT unavailable).';
-        }
-      });
+        const badge=$('modeBadge'); const banner=$('videoModeBanner');
+        if(badge && /ChatGPT/i.test(badge.textContent)){ badge.textContent='Mode: ChatGPT (temporary built-in fallback used)'; }
+        if(banner && /ChatGPT/i.test(banner.innerHTML)){ banner.innerHTML='Scoring via <strong>built-in heuristic engine</strong> (ChatGPT unavailable).'; }
+      }
       return;
     }
-    scoreWithBuiltin(type, raw);
+    await scoreWithBuiltin(type,raw,postureRes);
     showProvenance('Built-in score used (ChatGPT mode not active).', true);
   }
 

--- a/posture.js
+++ b/posture.js
@@ -67,6 +67,10 @@
         setTimeout(process,200);
       }
       function finish(){
+        pose.close();
+        video.pause();
+        video.remove();
+        canvas.remove();
         if(frames===0){resolve({score:0,posture:0,gesture:0,movement:0,advice:'No posture data'});return;}
         const sAvg=spine/frames;
         const shAvg=shoulder/frames;

--- a/posture.js
+++ b/posture.js
@@ -16,6 +16,7 @@
     const ctx=canvas.getContext('2d');
 
     let frames=0,spine=0,shoulder=0,elbow=0,knee=0;
+    let wristMove=0,bodyMove=0,lastL=null,lastR=null,lastHip=null;
 
     function angle(a,b,c){
       const ab={x:a.x-b.x,y:a.y-b.y};
@@ -43,6 +44,17 @@
           const lKn=angle(lm[23],lm[25],lm[27]);
           const rKn=angle(lm[24],lm[26],lm[28]);
           knee+=Math.abs(180-lKn)+Math.abs(180-rKn);
+          if(lastL&&lastR&&lastHip){
+            wristMove+=Math.hypot(lm[15].x-lastL.x,lm[15].y-lastL.y);
+            wristMove+=Math.hypot(lm[16].x-lastR.x,lm[16].y-lastR.y);
+            const hipC={x:(lm[23].x+lm[24].x)/2,y:(lm[23].y+lm[24].y)/2};
+            bodyMove+=Math.hypot(hipC.x-lastHip.x,hipC.y-lastHip.y);
+            lastHip=hipC;
+          }else{
+            lastHip={x:(lm[23].x+lm[24].x)/2,y:(lm[23].y+lm[24].y)/2};
+          }
+          lastL=lm[15];
+          lastR=lm[16];
           frames++;
         }
       });
@@ -55,7 +67,7 @@
         setTimeout(process,200);
       }
       function finish(){
-        if(frames===0){resolve({score:0,advice:'No posture data'});return;}
+        if(frames===0){resolve({score:0,posture:0,gesture:0,movement:0,advice:'No posture data'});return;}
         const sAvg=spine/frames;
         const shAvg=shoulder/frames;
         const elAvg=elbow/frames/2;
@@ -64,13 +76,26 @@
         const shScore=Math.max(0,10-shAvg*40);
         const elScore=Math.max(0,10-elAvg/9);
         const knScore=Math.max(0,10-knAvg/9);
-        const final=(sScore+shScore+elScore+knScore)/4;
+        const wristAvg=wristMove/frames;
+        const bodyAvg=bodyMove/frames;
+        const gestScore=Math.max(0,10-wristAvg*50);
+        const moveScore=Math.max(0,10-bodyAvg*50);
+        const postureScore=(sScore+shScore+elScore+knScore)/4;
+        const final=(postureScore+gestScore+moveScore)/3;
         const tips=[];
         if(sAvg>5) tips.push('keep your back straighter');
         if(shAvg>0.03) tips.push('level your shoulders');
         if(elAvg>25) tips.push('steady your elbows');
         if(knAvg>25) tips.push('avoid locking knees');
-        resolve({score:+final.toFixed(1),advice:tips.join('; ')});
+        if(wristAvg>0.02) tips.push('steady your hand gestures');
+        if(bodyAvg>0.01) tips.push('reduce body movement');
+        resolve({
+          score:+final.toFixed(1),
+          posture:+postureScore.toFixed(1),
+          gesture:+gestScore.toFixed(1),
+          movement:+moveScore.toFixed(1),
+          advice:tips.join('; ')
+        });
       }
       video.onloadeddata=()=>{video.play();process();};
       video.onerror=()=>finish();

--- a/posture.js
+++ b/posture.js
@@ -1,0 +1,82 @@
+// Basic posture analysis using MediaPipe Pose
+(function(global){
+  async function score(blob){
+    if(!global.Pose||!global.Pose.Pose){
+      throw new Error('Mediapipe Pose not loaded');
+    }
+    const pose=new global.Pose.Pose({
+      locateFile:file=>`https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5/${file}`
+    });
+    pose.setOptions({modelComplexity:1,smoothLandmarks:true,minDetectionConfidence:0.5,minTrackingConfidence:0.5});
+
+    const video=document.createElement('video');
+    video.src=URL.createObjectURL(blob);
+    video.muted=true;
+    const canvas=document.createElement('canvas');
+    const ctx=canvas.getContext('2d');
+
+    let frames=0,spine=0,shoulder=0,elbow=0,knee=0;
+
+    function angle(a,b,c){
+      const ab={x:a.x-b.x,y:a.y-b.y};
+      const cb={x:c.x-b.x,y:c.y-b.y};
+      const dot=ab.x*cb.x+ab.y*cb.y;
+      const magA=Math.hypot(ab.x,ab.y),magB=Math.hypot(cb.x,cb.y);
+      return Math.acos(Math.min(1,Math.max(-1,dot/(magA*magB))))*180/Math.PI;
+    }
+    function spineAngle(lm){
+      const hip=lm[24],shoulderPt=lm[12];
+      const dx=shoulderPt.x-hip.x,dy=shoulderPt.y-hip.y;
+      const ang=Math.atan2(dy,dx)*180/Math.PI;
+      return Math.abs(90-ang);
+    }
+
+    return new Promise(resolve=>{
+      pose.onResults(res=>{
+        if(res.poseLandmarks){
+          const lm=res.poseLandmarks;
+          spine+=spineAngle(lm);
+          shoulder+=Math.abs(lm[11].y-lm[12].y);
+          const lEl=angle(lm[11],lm[13],lm[15]);
+          const rEl=angle(lm[12],lm[14],lm[16]);
+          elbow+=Math.abs(90-lEl)+Math.abs(90-rEl);
+          const lKn=angle(lm[23],lm[25],lm[27]);
+          const rKn=angle(lm[24],lm[26],lm[28]);
+          knee+=Math.abs(180-lKn)+Math.abs(180-rKn);
+          frames++;
+        }
+      });
+
+      function process(){
+        if(video.paused||video.ended){finish();return;}
+        canvas.width=video.videoWidth;canvas.height=video.videoHeight;
+        ctx.drawImage(video,0,0,canvas.width,canvas.height);
+        pose.send({image:canvas});
+        setTimeout(process,200);
+      }
+      function finish(){
+        if(frames===0){resolve({score:0,advice:'No posture data'});return;}
+        const sAvg=spine/frames;
+        const shAvg=shoulder/frames;
+        const elAvg=elbow/frames/2;
+        const knAvg=knee/frames/2;
+        const sScore=Math.max(0,10-sAvg*0.2);
+        const shScore=Math.max(0,10-shAvg*40);
+        const elScore=Math.max(0,10-elAvg/9);
+        const knScore=Math.max(0,10-knAvg/9);
+        const final=(sScore+shScore+elScore+knScore)/4;
+        const tips=[];
+        if(sAvg>5) tips.push('keep your back straighter');
+        if(shAvg>0.03) tips.push('level your shoulders');
+        if(elAvg>25) tips.push('steady your elbows');
+        if(knAvg>25) tips.push('avoid locking knees');
+        resolve({score:+final.toFixed(1),advice:tips.join('; ')});
+      }
+      video.onloadeddata=()=>{video.play();process();};
+      video.onerror=()=>finish();
+    });
+  }
+
+  global.Posture={score};
+})(window);
+


### PR DESCRIPTION
## Summary
- integrate MediaPipe-based posture analysis for video uploads and recordings
- combine posture score with existing rubric using configurable weight and display results

## Testing
- `node --check posture.js && echo 'posture.js syntax ok'`
- `python -m py_compile generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4dd709f748331808d5da34c0a42f4