### PR TITLE
Centralize ChatGPT prompt construction across models

### DIFF
--- a/index.html
+++ b/index.html
@@ -1887,6 +1887,11 @@ const VideoCoach=(function(){
     return ChatGPTScoring.buildScoringPrompt(transcript, false, rubric);
   }
 
+  function buildChatGPTMessages(type, transcript){
+    const prompt = buildChatGPTPrompt(type, transcript);
+    return [{role:'user', content: prompt}];
+  }
+
   function parseChatGPTScoreResponse(text){
     const obj = extractFirstJson(text);
     if(!obj) throw new Error('bad_json');
@@ -1901,8 +1906,8 @@ const VideoCoach=(function(){
     const maxTokens = EngineState.openaiMaxTokens || 600;
     const tokenParam = chatTokenParam(model, maxTokens);
 
-    const prompt = buildChatGPTPrompt(type, transcript);
-    const messages = [{role:'user',content:prompt}];
+    const messages = buildChatGPTMessages(type, transcript);
+    const prompt = messages[0].content;
 
     async function callOnce(signal){
       if(DEBUG_CHATGPT){

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mocktrialacademy.com/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-02</lastmod>
   </url>
   <url>
     <loc>https://mocktrialacademy.com/contact.html</loc>


### PR DESCRIPTION
## Summary
- add `buildChatGPTMessages` helper to ensure identical prompts reach any ChatGPT model
- refactor scoring routine to use shared message builder
- regenerate sitemap

## Testing
- `python -m py_compile generate_sitemap.py`
- `python generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68b77b14d25c8331a32953abc5cf9a70