### PR TITLE
Extract posture analyzer into standalone module

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,8 +267,10 @@ a.inline{color:var(--accent);text-decoration:underline}
       <button id="btnShowCriteria" class="btn secondary">Show Criteria</button>
       <button id="btnChangeEngine" class="btn secondary" title="Switch scoring engine or update API key">API Key / Engine</button>
       <button id="btnTestChatGPT" class="btn secondary" title="Send a tiny test to ChatGPT">Test ChatGPT</button>
+      <button id="btnRatePosture" class="btn secondary">Rate Body Language</button>
     </div>
     <div id="videoFeedback" class="small"></div>
+    <div id="postureFeedback" class="small" style="margin-top:4px"></div>
     <div id="videoRubricDetails" class="small" style="display:none"></div>
     <div id="videoCriteria" class="small" style="display:none"></div>
     <div id="videoObjections" class="small" style="margin-top:10px"></div>
@@ -1465,7 +1467,8 @@ function wire(){populate();$('btnNewObj').addEventListener('click',newQ);$('btnC
 
 /* Video Coach (ChatGPT integration + fallback) */
 const VideoCoach=(function(){
-  let stream=null,rec=null,chunks=[],timer=null,sec=0,recog=null, micOnly=false, uploaded=false, uploadedURL=null;
+  let stream=null,rec=null,chunks=[],timer=null,sec=0,recog=null,
+      micOnly=false, uploaded=false, uploadedURL=null, lastVideoBlob=null;
 
   const EXEMPLARS={
     opening:{title:"Opening Exemplar",text:`Theme: choices have consequences. Today, the evidence will show that on June 12th,
@@ -1824,7 +1827,7 @@ const VideoCoach=(function(){
     try{ stream=await navigator.mediaDevices.getUserMedia({video:true,audio:true}); $('videoPreview').srcObject=stream; $('videoPreview').muted=true; await $('videoPreview').play(); }
     catch(e){ setStatus('Camera/mic error: '+e.message+'. Try Mic Only or Upload Video.', true); return; }
     chunks=[]; try{ rec=new MediaRecorder(stream); }catch(e){ setStatus('MediaRecorder not supported: '+e.message+'. You can still use Mic Only.', true); rec=null; }
-    if(rec){ rec.ondataavailable=e=>{ if(e.data&&e.data.size) chunks.push(e.data) }; rec.onstop=()=>{ const blob=new Blob(chunks,{type:'video/webm'}); const url=URL.createObjectURL(blob); $('btnDownloadRecording').href=url; $('btnPlayRecording').onclick=()=>{ const v=$('videoPreview'); v.srcObject=null; v.src=url; v.controls=true; v.play(); }; }; rec.start(); }
+    if(rec){ rec.ondataavailable=e=>{ if(e.data&&e.data.size) chunks.push(e.data) }; rec.onstop=()=>{ const blob=new Blob(chunks,{type:'video/webm'}); lastVideoBlob=blob; const url=URL.createObjectURL(blob); $('btnDownloadRecording').href=url; $('btnPlayRecording').onclick=()=>{ const v=$('videoPreview'); v.srcObject=null; v.src=url; v.controls=true; v.play(); }; }; rec.start(); }
     sec=0; tUpd(); if(timer) clearInterval(timer); timer=setInterval(()=>{sec++;tUpd()},1000);
     $('btnVideoStart').disabled=true; $('btnStopRecording').disabled=false; setStatus('Recording\u2026');
     try{
@@ -1851,6 +1854,7 @@ const VideoCoach=(function(){
 
   function handleUpload(file){
     if(!file) return; uploaded=true; micOnly=false;
+    lastVideoBlob=file;
     if(uploadedURL){ URL.revokeObjectURL(uploadedURL); uploadedURL=null; }
     uploadedURL=URL.createObjectURL(file);
     const v=$('videoPreview'); v.srcObject=null; v.src=uploadedURL; v.controls=true; v.play();
@@ -1867,6 +1871,54 @@ const VideoCoach=(function(){
     $('btnVideoStart').disabled=false; $('btnStopRecording').disabled=true;
     setStatus('Stopped. You can Re-score after editing transcript.');
     setTimeout(scoreNow,250);
+  }
+
+  async function loadPostureModule(){
+    if(window.analyzeBodyLanguage) return;
+    await new Promise((res,rej)=>{
+      const s=document.createElement('script');
+      s.src='posture.js';
+      s.onload=res;
+      s.onerror=rej;
+      document.head.appendChild(s);
+    });
+  }
+
+  async function fetchPostureAdvice(events, transcript){
+    if(!(EngineState.mode==='chatgpt' && EngineState.openaiKey)) return null;
+    try{
+      const model=EngineState.openaiModel||'gpt-4o-mini';
+      const timeline=events.map(e=>`${e.time}s: ${e.issue}`).join('\n')||'none';
+      const prompt=`You are a body-language coach. Given a speech transcript and a timeline of body-language issues, suggest specific movements or gestures and provide a brief summary. Return JSON {"tips":[{"time":number,"advice":string}],"summary":string}.\nTranscript:\n${transcript}\nTimeline:\n${timeline}`;
+      const resp=await fetch('https://api.openai.com/v1/chat/completions',{
+        method:'POST',
+        headers:{'Content-Type':'application/json','Authorization':`Bearer ${EngineState.openaiKey}`},
+        body:JSON.stringify({model,messages:[{role:'user',content:prompt}],max_tokens:200,temperature:0.5,response_format:{type:'json_object'}})
+      });
+      const text=await resp.text();
+      return extractFirstJson(text);
+    }catch(err){console.error('posture advice',err);return null;}
+  }
+
+  async function ratePosture(){
+    try{
+      const blob=lastVideoBlob;
+      if(!blob){
+        $('videoStatus').textContent='No video available for posture scoring.';
+        return;
+      }
+      await loadPostureModule();
+      setStatus('Scoring body language...');
+      const res=await analyzeBodyLanguage(blob);
+      const ev=(res && Array.isArray(res.events))?res.events:[];
+      const gpt=await fetchPostureAdvice(ev, $('videoTranscript').value||'');
+      const timelineHtml=ev.map(e=>`<li>${e.time}s: ${escHTML(e.issue)}</li>`).join('');
+      const tipsHtml=gpt&&Array.isArray(gpt.tips)?gpt.tips.map(t=>`<li>${t.time}s: ${escHTML(t.advice)}</li>`).join(''):'';
+      $('postureFeedback').innerHTML=`<div class="kv small"><div>Final Body Score</div><div>${res.score}/10</div><div>Posture</div><div>${res.posture}/10</div><div>Gesture</div><div>${res.gesture}/10</div><div>Movement</div><div>${res.movement}/10</div></div>${res.advice?`<div class="small" style="margin-top:4px"><strong>Body Tips:</strong> ${escHTML(res.advice)}</div>`:''}${ev.length?`<div class="small" style="margin-top:4px"><strong>Timeline:</strong><ul>${timelineHtml}</ul></div>`:''}${tipsHtml?`<div class="small" style="margin-top:4px"><strong>Suggested Moves:</strong><ul>${tipsHtml}</ul></div>`:''}${gpt&&gpt.summary?`<div class="small" style="margin-top:4px"><strong>Coach Notes:</strong> ${escHTML(gpt.summary)}</div>`:''}`;
+      $('videoStatus').textContent='Body language scored.';
+    }catch(e){
+      $('videoStatus').textContent='Body analysis failed: '+(e&&e.message?e.message:'');
+    }
   }
 
   function buildChatGPTPrompt(type, transcript){
@@ -2120,6 +2172,7 @@ const VideoCoach=(function(){
     $('btnStopRecording').disabled=true;
     $('btnChangeEngine').addEventListener('click', openVideoGate);
     $('btnTestChatGPT').addEventListener('click', testChatGPT);
+    $('btnRatePosture')?.addEventListener('click', ratePosture);
     $('btnGPTWrite').addEventListener('click', gptWrite);
     $('btnWriteChangeEngine')?.addEventListener('click', openVideoGate);
     renderModeBadge();

--- a/posture.js
+++ b/posture.js
@@ -1,0 +1,152 @@
+// Basic posture analysis using MediaPipe Pose
+async function ensurePose(){
+  if(window.Pose && window.Pose.Pose){return true;}
+  try{
+    await new Promise((res,rej)=>{
+      const s=document.createElement('script');
+      s.src='https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5/pose.min.js';
+      s.onload=res;
+      s.onerror=rej;
+      document.head.appendChild(s);
+    });
+  }catch(_){return false;}
+  return !!(window.Pose && window.Pose.Pose);
+}
+
+async function analyzeBodyLanguage(blob){
+  if(!await ensurePose()){
+    return {score:0,posture:0,gesture:0,movement:0,advice:'Pose model unavailable',events:[]};
+  }
+  const pose=new window.Pose.Pose({
+    locateFile:file=>`https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5/${file}`
+  });
+  pose.setOptions({modelComplexity:1,smoothLandmarks:true,minDetectionConfidence:0.5,minTrackingConfidence:0.5});
+
+  const video=document.createElement('video');
+  video.src=URL.createObjectURL(blob);
+  video.muted=true;
+  const canvas=document.createElement('canvas');
+  const ctx=canvas.getContext('2d');
+
+  let frames=0,spine=0,shoulder=0,elbow=0,knee=0;
+  let wristMove=0,bodyMove=0,lastL=null,lastR=null,lastHip=null;
+  let wristStill=0;
+  const events=[];
+  let done=false, finish;
+
+  function angle(a,b,c){
+    const ab={x:a.x-b.x,y:a.y-b.y};
+    const cb={x:c.x-b.x,y:c.y-b.y};
+    const dot=ab.x*cb.x+ab.y*cb.y;
+    const magA=Math.hypot(ab.x,ab.y),magB=Math.hypot(cb.x,cb.y);
+    return Math.acos(Math.min(1,Math.max(-1,dot/(magA*magB))))*180/Math.PI;
+  }
+
+  function dist(a,b){return Math.hypot(a.x-b.x,a.y-b.y);}
+
+  async function process(){
+    if(video.ended){finish();return;}
+    ctx.drawImage(video,0,0,canvas.width,canvas.height);
+    await pose.send({image:canvas});
+    requestAnimationFrame(process);
+  }
+
+  pose.onResults(r=>{
+    try{
+    frames++;
+    const lm=r.poseLandmarks;
+    if(!lm || lm.length<29){return;}
+    const L=lm[11],R=lm[12];
+    const H=lm[23],H2=lm[24];
+    const wristL=lm[15],wristR=lm[16];
+    const elbowL=lm[13],elbowR=lm[14];
+    const kneeL=lm[25],kneeR=lm[26],ankleL=lm[27],ankleR=lm[28];
+    if(!L||!R||!H||!H2||!wristL||!wristR||!elbowL||!elbowR||!kneeL||!kneeR||!ankleL||!ankleR){return;}
+    const spineAng=angle(L,H,H2);
+    const spineDiff=Math.abs(spineAng-180);
+    const shoulderDiff=Math.abs(L.y-R.y);
+    const elbowAng=angle(elbowL,L,wristL)+angle(elbowR,R,wristR);
+    const kneeAng=angle(kneeL,H,ankleL)+angle(kneeR,H2,ankleR);
+    spine+=spineDiff;
+    shoulder+=shoulderDiff;
+    elbow+=elbowAng;
+    knee+=kneeAng;
+    const handMove=lastL&&lastR?dist(wristL,lastL)+dist(wristR,lastR):0;
+    const hipMove=lastHip?dist(H,lastHip):0;
+    wristMove+=handMove;
+    bodyMove+=hipMove;
+    if(handMove<0.01){wristStill++;}else{wristStill=0;}
+    function mark(issue){
+      const t=video.currentTime;
+      events.push({time:+t.toFixed(1),issue});
+    }
+    if(wristStill>30){mark('add hand gesture to emphasize point');wristStill=0;}
+    if(hipMove>0.1) mark('transition—keep movements smooth');
+    const handLevel=(wristL.y+wristR.y)/2;
+    const shoulderLevel=(L.y+R.y)/2;
+    if(handLevel>H.y+0.1) mark('raise hands toward waist level');
+    else if(handLevel<shoulderLevel-0.1) mark('lower hands to chest height');
+    if(spineDiff>5) mark('keep your back straighter');
+    if(shoulderDiff>0.03) mark('level your shoulders');
+    if(elbowAng/2>25) mark('keep elbows near 90°');
+    if(kneeAng/2>25) mark('avoid locking knees');
+    lastL=wristL;
+    lastR=wristR;
+    lastHip=H;
+    }catch(_){/* ignore frame errors */}
+  });
+
+  return new Promise(resolve=>{
+    finish=function(){
+      if(done) return;
+      done=true;
+      pose.close();
+      URL.revokeObjectURL(video.src);
+      video.remove();
+      canvas.remove();
+      if(frames===0){resolve({score:0,posture:0,gesture:0,movement:0,advice:'No posture data',events:[]});return;}
+      const sAvg=spine/frames;
+      const shAvg=shoulder/frames;
+      const elAvg=elbow/frames/2;
+      const knAvg=knee/frames/2;
+      const sScore=Math.max(0,10-sAvg*0.2);
+      const shScore=Math.max(0,10-shAvg*40);
+      const elScore=Math.max(0,10-elAvg/9);
+      const knScore=Math.max(0,10-knAvg/9);
+      const wristAvg=wristMove/frames;
+      const bodyAvg=bodyMove/frames;
+      const gestScore=Math.max(0,10-wristAvg*50);
+      const moveScore=Math.max(0,10-bodyAvg*50);
+      const postureScore=(sScore+shScore+elScore+knScore)/4;
+      const final=(postureScore+gestScore+moveScore)/3;
+      const tips=[];
+      if(sAvg>5) tips.push('keep your back straighter');
+      if(shAvg>0.03) tips.push('level your shoulders');
+      if(elAvg>25) tips.push('steady your elbows');
+      if(knAvg>25) tips.push('avoid locking knees');
+      if(wristAvg>0.02) tips.push('steady your hand gestures');
+      if(bodyAvg>0.01) tips.push('reduce body movement');
+      resolve({
+        score:+final.toFixed(1),
+        posture:+postureScore.toFixed(1),
+        gesture:+gestScore.toFixed(1),
+        movement:+moveScore.toFixed(1),
+        advice:tips.join('; '),
+        events
+      });
+    };
+    video.onloadeddata=()=>{
+      canvas.width=video.videoWidth;
+      canvas.height=video.videoHeight;
+      video.play();
+      requestAnimationFrame(process);
+    };
+    video.onended=finish;
+    video.onerror=finish;
+  });
+}
+
+if(typeof window!=='undefined'){
+  window.analyzeBodyLanguage = analyzeBodyLanguage;
+}
+


### PR DESCRIPTION
## Summary
- Request movement tips from GPT using video transcript and posture-event timeline
- Present final body score with posture, gesture, and movement breakdowns and timestamped suggestions

## Testing
- `node --check posture.js`
- `python -m py_compile generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4dd709f748331808d5da34c0a42f4