### PR TITLE
fix: load posture analyzer on demand

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,8 +116,7 @@ hr.sep{border:0;border-top:1px solid rgba(0,0,0,.1);margin:12px 0}
 a.inline{color:var(--accent);text-decoration:underline}
 .hidden-link{color:inherit;text-decoration:none}
 </style>
-<!-- Human: all-in-one body/face/hands pose estimator (client-side) -->
-<script src="https://cdn.jsdelivr.net/npm/@vladmandic/human/dist/human.js"></script>
+<!-- Human: all-in-one body/face/hands pose estimator (client-side, loaded on-demand) -->
 </head>
 <body>
 <div class="app">
@@ -2722,8 +2721,14 @@ const PostureCoach = (() => {
 
   async function ensureHuman() {
     if (human) return human;
-    human = new Human.Human({
-      backend: 'webgl',
+    if (!globalThis._humanModule) {
+      globalThis._humanModule = import('https://cdn.jsdelivr.net/npm/@vladmandic/human/dist/human.esm.js');
+    }
+    const mod = await globalThis._humanModule;
+    const HumanLib = mod.Human || mod.default;
+    const backend = globalThis.navigator?.gpu ? 'webgpu' : 'webgl';
+    human = new HumanLib({
+      backend,
       filter: { enabled: true },
       modelBasePath: 'https://cdn.jsdelivr.net/npm/@vladmandic/human/models',
       face: { enabled: true },


### PR DESCRIPTION
## Summary
- Load Human.js library dynamically for posture coaching
- Prefer WebGPU backend when available for faster analysis

## Testing
- `python generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7aa0a5f68833191cebebde24a6b4b