### PR TITLE
feat: include improvement suggestions in ChatGPT scoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -736,11 +736,14 @@ Counter/exception credit (up to 1.5 + 1.5) boosts top-end scores when you neutra
 `   should reflect the transcript and not default to a midpoint score.\n`+
 `5. If no rule of evidence is cited, deduct up to 0.5 points (minor deduction).\n`+
 `6. Provide a brief explanation for why you chose that score, referring to \n`+
-`   the referenced sections of the transcript and noting where the participant can improve or what they should have done differently, pointing out specific lines or phrases to revise.\n\n`+
+`   the referenced sections of the transcript and noting where the participant can improve or what they should have done differently, pointing out specific lines or phrases to revise.\n`+
+`7. List specific improvement suggestions, quoting exact words or phrases \n`+
+`   from the transcript and offering concrete alternative wording or steps.\n\n`+
 `Format your response as:\n`+
 `Summary: <detailed summary with references>\n`+
 `Score: <number from 1 to 10>\n`+
-`Explanation: <short paragraph including specific, actionable suggestions>`;
+`Explanation: <short paragraph explaining the score>\n`+
+`Improvements: <specific, actionable suggestions>`;
 
 const PROMPT_TEMPLATE_RULING =
 `You are a neutral evaluator acting as a mock trial high school judge.\n\n`+
@@ -758,12 +761,15 @@ const PROMPT_TEMPLATE_RULING =
 `5. If no rule of evidence is cited, deduct up to 0.5 points (minor deduction).\n`+
 `6. Decide whether the objection should be sustained or overruled.\n`+
 `7. Provide a brief explanation for why you chose that score, referring to \n`+
-`   the referenced sections of the transcript and noting where the participant can improve or what they should have done differently, pointing out specific lines or phrases to revise.\n\n`+
+`   the referenced sections of the transcript and noting where the participant can improve or what they should have done differently, pointing out specific lines or phrases to revise.\n`+
+`8. List specific improvement suggestions, quoting exact words or phrases \n`+
+`   from the transcript and offering concrete alternative wording or steps.\n\n`+
 `Format your response as:\n`+
 `Ruling: <Sustained or Overruled>\n`+
 `Summary: <detailed summary with references>\n`+
 `Score: <number from 1 to 10>\n`+
-`Explanation: <short paragraph including specific, actionable suggestions>`;
+`Explanation: <short paragraph explaining the score>\n`+
+`Improvements: <specific, actionable suggestions>`;
 
   const PROMPT_PREFIX = "Important: Apply the FLOORS exactly as written; do not reduce below them unless the transcript itself disproves the required condition(s).";
 
@@ -1188,10 +1194,14 @@ function appendJudgeDecision(res){
  const score=document.createElement('div');
  score.innerHTML=`<strong>Score:</strong> ${escHTML(res.score)}`;
  div.appendChild(score);
- const explanationText = res.improvement ? `${res.explanation} ${res.improvement}` : res.explanation;
  const explain=document.createElement('div');
- explain.innerHTML=`<strong>Explanation:</strong> ${escHTML(explanationText)}`;
+ explain.innerHTML=`<strong>Explanation:</strong> ${escHTML(res.explanation)}`;
  div.appendChild(explain);
+ if(res.improvement){
+  const improv=document.createElement('div');
+  improv.innerHTML=`<strong>Improvements:</strong> ${escHTML(res.improvement)}`;
+  div.appendChild(improv);
+ }
  out.appendChild(div);
  out.scrollTop=out.scrollHeight;
 }


### PR DESCRIPTION
## Summary
- Prompt ChatGPT to return a dedicated `Improvements` section for all scoring requests
- Display explanation and improvement tips separately in judge feedback

## Testing
- `python -m py_compile generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68b910f0202483319a4c95e15e77c5fa