### PR TITLE
Improve mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 .header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:12px;position:relative}
 .title-block{flex:1}
 .logo{width:calc(44px*1.25);height:calc(44px*1.25);border-radius:8px;display:flex;align-items:center;justify-content:center;background:linear-gradient(135deg,#3b82f6 70%,#f59e0b);font-weight:700;color:#fff;border:2px solid #1e293b;}
-.nav-menu{position:fixed;top:0;right:0;bottom:0;width:180px;background:var(--card);border-left:1px solid rgba(0,0,0,.1);box-shadow:0 0 8px rgba(0,0,0,.1);display:flex;flex-direction:column;z-index:1000;padding:10px;transform:translateX(100%);transition:transform .3s}
+.nav-menu{position:fixed;top:0;right:0;bottom:0;width:180px;background:var(--card);border-left:1px solid rgba(0,0,0,.1);box-shadow:0 0 8px rgba(0,0,0,.1);display:flex;flex-direction:column;z-index:1000;padding:10px;transform:translateX(100%);transition:transform .3s;overflow-y:auto}
 .nav-menu.open{transform:translateX(0)}
 .nav-menu .tab{background:transparent;border:none;padding:10px 12px;text-align:left;color:var(--text);cursor:pointer}
 .nav-menu .tab.active{background:var(--secondary)}
@@ -108,6 +108,10 @@ textarea{width:100%;min-height:120px;background:var(--card);color:var(--text);bo
 .warn{background:#fef2f2;color:#991b1b;border:1px solid #fca5a5;padding:6px 8px;border-radius:8px;font-size:1em}
 .ok{background:#f0fdf4;color:#166534;border:1px solid #6ee7b7;padding:6px 8px;border-radius:8px}
 .badge-mode{font-size:0.6em;padding:1px 4px;border-radius:999px;background:var(--secondary);color:var(--text);margin-left:6px}
+@media(max-width:600px){
+  .header{flex-direction:column;align-items:flex-start}
+  .nav-menu{width:100%}
+}
 .chat-entry{margin-top:8px;padding:6px;border-radius:6px;border:1px solid rgba(0,0,0,.1)}
 .chat-entry.user{background:var(--secondary)}
 .chat-entry.chatgpt{background:var(--accent);color:#fff}


### PR DESCRIPTION
## Summary
- Allow navigation menu to scroll and span full width on small screens
- Stack header elements vertically on narrow devices for better readability

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ba4f6bd4d88331a8402571431dcb17