### PR TITLE
fix: make section redirect pages path-relative

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -10,13 +10,13 @@
     gtag('config', 'G-3QMGWMD9KZ');
   </script>
   <meta charset="utf-8">
-  <meta http-equiv="refresh" content="0; url=/#contact">
+  <meta http-equiv="refresh" content="0; url=./#contact">
   <title>Contact MT academy</title>
   <meta name="description" content="Get in touch with MT academy for support or inquiries.">
 </head>
 <body>
   <h1>Contact</h1>
   <p>Reach out with questions, suggestions, or feedback.</p>
-  <p>Find contact options on the <a href="/#contact">main MT academy page</a>.</p>
+  <p>Find contact options on the <a href="./#contact">main MT academy page</a>.</p>
 </body>
 </html>

--- a/howto.html
+++ b/howto.html
@@ -10,13 +10,13 @@
     gtag('config', 'G-3QMGWMD9KZ');
   </script>
   <meta charset="utf-8">
-  <meta http-equiv="refresh" content="0; url=/#howto">
+  <meta http-equiv="refresh" content="0; url=./#howto">
   <title>How to Use MT academy</title>
   <meta name="description" content="Learn how to navigate and use the tools available on MT academy.">
 </head>
 <body>
   <h1>How to Use</h1>
   <p>Instructions for getting the most out of MT academy's mock trial tools.</p>
-  <p>Read the guide on the <a href="/#howto">main MT academy page</a>.</p>
+  <p>Read the guide on the <a href="./#howto">main MT academy page</a>.</p>
 </body>
 </html>

--- a/objections.html
+++ b/objections.html
@@ -10,13 +10,13 @@
     gtag('config', 'G-3QMGWMD9KZ');
   </script>
   <meta charset="utf-8">
-  <meta http-equiv="refresh" content="0; url=/#objections">
+  <meta http-equiv="refresh" content="0; url=./#objections">
   <title>Objections Drill – MT academy</title>
   <meta name="description" content="Practice mock trial objections with MT academy's interactive drill.">
 </head>
 <body>
   <h1>Objections Drill</h1>
   <p>Practice mock trial objections with filtering, difficulty levels, and scoring options.</p>
-  <p>Use this tool on the <a href="/#objections">main MT academy page</a>.</p>
+  <p>Use this tool on the <a href="./#objections">main MT academy page</a>.</p>
 </body>
 </html>

--- a/quiz.html
+++ b/quiz.html
@@ -10,13 +10,13 @@
     gtag('config', 'G-3QMGWMD9KZ');
   </script>
   <meta charset="utf-8">
-  <meta http-equiv="refresh" content="0; url=/#quiz">
+  <meta http-equiv="refresh" content="0; url=./#quiz">
   <title>Rules Quiz – MT academy</title>
   <meta name="description" content="Test your knowledge of mock trial rules with MT academy's quiz.">
 </head>
 <body>
   <h1>Rules Quiz</h1>
   <p>Challenge yourself with questions on the rules of evidence and procedure.</p>
-  <p>Take the quiz on the <a href="/#quiz">main MT academy page</a>.</p>
+  <p>Take the quiz on the <a href="./#quiz">main MT academy page</a>.</p>
 </body>
 </html>

--- a/rules.html
+++ b/rules.html
@@ -10,13 +10,13 @@
     gtag('config', 'G-3QMGWMD9KZ');
   </script>
   <meta charset="utf-8">
-  <meta http-equiv="refresh" content="0; url=/#rules">
+  <meta http-equiv="refresh" content="0; url=./#rules">
   <title>Rules of Evidence Explorer – MT academy</title>
   <meta name="description" content="Browse the Arizona High School Mock Trial Rules of Evidence with explanations.">
 </head>
 <body>
   <h1>AZ HS Mock Trial Rules of Evidence</h1>
   <p>Search and read detailed explanations of the Arizona mock trial evidence rules.</p>
-  <p>Use the explorer on the <a href="/#rules">main MT academy page</a>.</p>
+  <p>Use the explorer on the <a href="./#rules">main MT academy page</a>.</p>
 </body>
 </html>

--- a/video-coach.html
+++ b/video-coach.html
@@ -10,13 +10,13 @@
     gtag('config', 'G-3QMGWMD9KZ');
   </script>
   <meta charset="utf-8">
-  <meta http-equiv="refresh" content="0; url=/#video">
+  <meta http-equiv="refresh" content="0; url=./#video">
   <title>Video Coach – MT academy</title>
   <meta name="description" content="Record, transcribe, and score performances with MT academy's Video Coach.">
 </head>
 <body>
   <h1>Video Coach</h1>
   <p>Record, transcribe, and score mock trial performances using type-specific rubrics and objection detection.</p>
-  <p>Access the full tool on the <a href="/#video">main MT academy page</a>.</p>
+  <p>Access the full tool on the <a href="./#video">main MT academy page</a>.</p>
 </body>
 </html>

--- a/writing.html
+++ b/writing.html
@@ -10,13 +10,13 @@
     gtag('config', 'G-3QMGWMD9KZ');
   </script>
   <meta charset="utf-8">
-  <meta http-equiv="refresh" content="0; url=/#writing">
+  <meta http-equiv="refresh" content="0; url=./#writing">
   <title>Writing New Materials – MT academy</title>
   <meta name="description" content="Generate mock trial materials and prompts using MT academy's writing tools.">
 </head>
 <body>
   <h1>Writing New Materials</h1>
   <p>Use AI to create case materials, questions, and arguments for mock trial practice.</p>
-  <p>Explore this feature on the <a href="/#writing">main MT academy page</a>.</p>
+  <p>Explore this feature on the <a href="./#writing">main MT academy page</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Use relative redirects and links in standalone HTML pages so they correctly load index sections regardless of hosting path

## Testing
- `python3 -m py_compile generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba533d789c8331bf9001117e96d492