### PR TITLE
fix: close browser check scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1033,6 +1033,8 @@ window.addEventListener('unhandledrejection', e=>{
 /* Legacy stub retained */
 function evaluateRubric(){ return {org:4,delivery:5,content:4,presence:6,words:0,wpm:0,fillers:0,legalKeywords:0,signposts:0}; }
 
+} // end browser check
+
 </script>
 <script>
 // --- Global audio helpers (used by Objections + Video Coach) ---
@@ -1095,6 +1097,7 @@ function evaluateRubric(){ return {org:4,delivery:5,content:4,presence:6,words:0
 })();
 </script>
 <script>
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
 /* Objections module (full) */
 const OBJECTION_CHOICES=["Hearsay","Hearsay within Hearsay","Leading","Speculation","Lack of Foundation","Lack of Personal Knowledge","Compound","Improper Character","Improper Opinion","Asked & Answered","Relevance","Argumentative","Vague/Ambiguous","Nonresponsive","Beyond Scope","Assumes Facts Not in Evidence","Narrative","Misstates Evidence","Cumulative","Subsequent Remedial Measures","Compromise/Offers","Medical Payments","Plea Discussions","Insurance"];
 


### PR DESCRIPTION
## Summary
- close browser environment guard before starting new scripts
- wrap remaining scripts in their own browser check

## Testing
- `python -m py_compile generate_sitemap.py`
- `node - <<'NODE'
const fs=require('fs');
const html=fs.readFileSync('index.html','utf8');
const scripts=[...html.matchAll(/<script([^>]*)>([\s\S]*?)<\/script>/g)];
for(let i=0;i<scripts.length;i++){
  const attrs=scripts[i][1]; const content=scripts[i][2];
  if(/type="application\/ld\+json"/.test(attrs) || /src=/.test(attrs)) continue;
  try{ new Function(content); console.log('script',i,'parsed'); }catch(e){ console.log('script',i,'error',e.message); }
}
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68ba54da9bcc8331acf4b9cfeae9021a