### PR TITLE
Simplify How to Use instructions

### DIFF
--- a/howto.html
+++ b/howto.html
@@ -12,11 +12,11 @@
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=./#howto">
   <title>How to Use MT academy</title>
-  <meta name="description" content="Learn how to navigate and use the tools available on MT academy.">
+  <meta name="description" content="Quick guide for the Objections, Video Coach, Writing, Rules, Rules Quiz, and API key setup including Gemini.">
 </head>
 <body>
   <h1>How to Use</h1>
-  <p>Instructions for getting the most out of MT academy's mock trial tools.</p>
-  <p>Read the guide on the <a href="./#howto">main MT academy page</a>.</p>
+  <p>Quick tips for MT academy's practice tools and API key setup.</p>
+  <p>See the full instructions on the <a href="./#howto">main page</a>.</p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -346,20 +346,20 @@ a.inline{color:var(--accent);text-decoration:underline}
   <!-- How To -->
   <section id="howto" class="card">
     <h2>How to Use</h2>
-    <p class="small">Use the tabs above to explore the different practice tools.</p>
+    <p class="small">Open a tab for the tool you need and follow these steps.</p>
     <ul class="small">
-      <li><a href="objections.html" class="hidden-link"><strong>Objections:</strong></a> filter by topic and difficulty, click <em>New Drill</em> for a fresh scenario, pick an objection, then <em>Check</em>. Use <em>GPT Prompt</em> or <em>ChatGPT Argue</em> (with text or audio and role selection) to practice with AI; <em>Reset Stats</em> clears progress.</li>
-      <li><a href="video-coach.html" class="hidden-link"><strong>Video Coach:</strong></a> choose the speech type, record, then view <em>Metrics</em> and the objection finder. Use <em>Re-score</em> or <em>Download</em> as needed. The <em>API Key / Engine</em> option enables ChatGPT-based scoring and testing and lets you save a Gemini key for <em>Movement</em> analysis.</li>
-      <li><a href="writing.html" class="hidden-link"><strong>Writing:</strong></a> choose a type, add your notes and goals, then click <em>Ask ChatGPT to Draft</em> to get help writing new material; use <em>API Key / Engine</em> to pick the model.</li>
-      <li><a href="rules.html" class="hidden-link"><strong>Rules:</strong></a> search by number or topic, then tap a rule to see the text and a plain-language <em>What it means</em> explanation.</li>
-      <li><a href="quiz.html" class="hidden-link"><strong>Rules Quiz:</strong></a> choose mode, rule set, question count and difficulty, then hit <em>Start Quiz</em>. Use <em>Next</em> to advance; the top shows your score and best.</li>
+      <li><a href="objections.html" class="hidden-link"><strong>Objections:</strong></a> Pick a topic and difficulty, hit <em>New Drill</em>, then decide whether the judge should sustain or overrule. Click <em>Check</em> for the answer. <em>ChatGPT Argue</em> lets you debate the AI and <em>GPT Prompt</em> takes custom practice. Use <em>Reset Stats</em> to wipe your record.</li>
+      <li><a href="video-coach.html" class="hidden-link"><strong>Video Coach:</strong></a> Choose a speech, allow camera and mic, and record. When you stop, review <em>Metrics</em> and the objection finder. Add an OpenAI key under <em>API Key / Engine</em> for scoring and optionally a Gemini key to analyze movement. Use <em>Re-score</em> for another attempt or <em>Download</em> to save the session.</li>
+      <li><a href="writing.html" class="hidden-link"><strong>Writing:</strong></a> Select the document type, add your notes, and click <em>Ask ChatGPT to Draft</em>. Pick the model in <em>API Key / Engine</em> and edit the result as needed.</li>
+      <li><a href="rules.html" class="hidden-link"><strong>Rules:</strong></a> Search by number or topic to read the rule and its plain‑language explanation.</li>
+      <li><a href="quiz.html" class="hidden-link"><strong>Rules Quiz:</strong></a> Choose practice or test mode, pick a rule set, set the question count and difficulty, then press <em>Start Quiz</em>. Use <em>Next</em> to move ahead; the top bar tracks your score and best.</li>
     </ul>
-    <h3>Upload an API Key</h3>
+    <h3>Save API Keys</h3>
     <ol class="small" style="margin-top:6px">
-      <li>Visit <strong>platform.openai.com</strong> and create an API key.</li>
-      <li>Open your profile → <em>Billing</em> and add funds with a card; the API will not work until you have credit.</li>
-      <li>In this app, click the “API Key” or “API Key / Engine” button.</li>
-      <li>Paste your key and choose a model. The key is stored only in your browser.</li>
+      <li>Create an OpenAI key at <strong>platform.openai.com</strong> and add a payment method. For movement analysis, make a Gemini key at <strong>ai.google.dev</strong>.</li>
+      <li>In MT academy, click “API Key” or “API Key / Engine”.</li>
+      <li>Paste the OpenAI key and choose a model for ChatGPT features. Paste the Gemini key to enable movement analysis in Video Coach.</li>
+      <li>Your keys stay only in this browser. Click “Remove” to forget them.</li>
     </ol>
   </section>
   <!-- Contact -->


### PR DESCRIPTION
## Summary
- Expand "How to Use" section with step-by-step guidance for each tool and updated explanations
- Add instructions for saving OpenAI and Gemini API keys
- Refresh standalone How to Use page metadata

## Testing
- `python -m py_compile generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcff7b01888331bb028670d8e533b6