### PR TITLE
Enhance mock trial scoring rubric with detailed criteria

### DIFF
--- a/index.html
+++ b/index.html
@@ -564,6 +564,10 @@ const MT_SCORING = (() => {
     "Discussed the burden of proof",
     "Presentation was non-argumentative; did not include improper statements or assume facts not in evidence",
     "Spoke naturally and clearly",
+    "Captured attention with a compelling hook or introduction",
+    "Presented a clear roadmap for what the judge would hear",
+    "Maintained professional courtroom demeanor and eye contact",
+    "Used notes sparingly and purposefully",
   ];
 
   const DIRECT_CRITERIA = [
@@ -576,6 +580,11 @@ const MT_SCORING = (() => {
     "Demonstrated an understanding of the Modified Federal Rules of Evidence",
     "Handled physical evidence appropriately and effectively",
     "Spoke confidently and clearly",
+    "Questions were predominantly open-ended and non-leading",
+    "Witness testimony advanced the team\u2019s case theory",
+    "Transitions between topics were smooth and logical",
+    "Established proper foundations for exhibits and testimony",
+    "Maintained effective witness control and rapport",
   ];
 
   const CROSS_CRITERIA = [
@@ -590,6 +599,11 @@ const MT_SCORING = (() => {
     "Demonstrated an understanding of the Modified Federal Rules of Evidence",
     "Handled physical evidence appropriately and effectively",
     "Spoke confidently and clearly",
+    "Questions were leading and limited to one fact each",
+    "Maintained tight control and prevented narrative responses",
+    "Listened to answers and adjusted follow-up questions",
+    "Elicited helpful admissions or undermined witness credibility",
+    "Concluded with a clear, memorable point",
   ];
 
   const CLOSING_CRITERIA = [
@@ -604,6 +618,11 @@ const MT_SCORING = (() => {
     "Use of notes was minimal, effective, and purposeful",
     "Contained spontaneous elements that reflect unanticipated outcomes of this specific trial",
     "Spoke naturally and clearly",
+    "Organized the argument with a clear roadmap",
+    "Addressed and refuted major points from the opposition",
+    "Integrated witness testimony and exhibits into the argument",
+    "Ended with a strong, memorable call for the verdict",
+    "Maintained professional demeanor and time awareness",
   ];
 
   function numericToGrade(score) {


### PR DESCRIPTION
## Summary
- Expand opening statement criteria to emphasize hooks, roadmaps, professionalism, and sparing use of notes
- Broaden direct and cross-examination rubrics to cover question style, witness control, and case theory advancement
- Extend closing argument rubric with structure, rebuttal, integration of evidence, and stronger finish

## Testing
- `python -m py_compile generate_sitemap.py`
- `python generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd0d6845f48331b3b7c6b52f0537e9