### PR TITLE
Add API key cost guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,6 +351,8 @@ a.inline{color:var(--accent);text-decoration:underline}
       <li>Paste the OpenAI key and choose a model for ChatGPT features. Paste the Gemini key to enable movement analysis in Video Coach.</li>
       <li>Your keys stay only in this browser. Click “Remove” to forget them.</li>
     </ol>
+    <h3>API Key Costs</h3>
+    <p class="small">You have to put money down for the ChatGPT API key; just put $5. For the Gemini API key, link it to a credit card; it's really cheap. If you can't afford it, then go get a job.</p>
   </section>
   <!-- Contact -->
   <section id="contact" class="card">


### PR DESCRIPTION
## Summary
- Add an "API Key Costs" section under How to Use, advising $5 deposit for ChatGPT API and credit card link for Gemini API

## Testing
- `python -m py_compile generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd23e0fc1c83318ddb37743af92fde