### PR TITLE
Refine voice feedback guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -2216,16 +2216,30 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
         }
       }
 
-      const points=rawPoints.map(pt=>{
-        let quote="";
-        if(pt.word) quote=` "${pt.word.trim()}"`;
-        else if(words.length){
-          const mid=pt.time+0.5;
-          const nearest=words.reduce((a,b)=>Math.abs(b.start-mid)<Math.abs(a.start-mid)?b:a);
-          if(Math.abs(nearest.start-mid)<=1.5) quote=` "${nearest.word.trim()}"`;
+      rawPoints.sort((a,b)=>a.time-b.time);
+      const merged=[];
+      for(const pt of rawPoints){
+        const last=merged[merged.length-1];
+        if(last && last.msg===pt.msg && pt.time-last.end<1){
+          last.end=pt.time;
+          if(pt.word) last.words.push(pt.word);
+        }else{
+          merged.push({msg:pt.msg,start:pt.time,end:pt.time,words:pt.word?[pt.word]:[]});
         }
+      }
+
+      const points=merged.map(group=>{
+        let phrase="";
+        if(group.words.length){
+          phrase=group.words.map(w=>w.trim()).join(' ');
+        }else if(words.length){
+          const mid=group.start+0.5;
+          const nearest=words.reduce((a,b)=>Math.abs(b.start-mid)<Math.abs(a.start-mid)?b:a);
+          if(Math.abs(nearest.start-mid)<=1.5) phrase=nearest.word.trim();
+        }
+        const quote=phrase?` "${phrase}"`:"";
         const around=quote?` around${quote}`:"";
-        switch(pt.msg){
+        switch(group.msg){
           case 'speak louder':
             return `Speak louder${around} to project confidence.`;
           case 'speak softer':
@@ -2243,7 +2257,7 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
           case 'speaking too slow':
             return `Speed up here${around} to maintain energy.`;
           default:
-            return `${pt.msg}${around}.`;
+            return `${group.msg}${around}.`;
         }
       });
 

--- a/index.html
+++ b/index.html
@@ -2141,6 +2141,7 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
       else if(toneRating==='Too much change') tips.push('Steady your tone.');
       else tips.push('Tone variation is good.');
       if(clarityRating!=='Clear') tips.push('Enunciate more for clarity.');
+      tips.push('Use strategic pauses and vary your pace for emphasis.');
 
       const rawPoints=[];
       const segLen=sampleRate; // 1s segments
@@ -2216,7 +2217,6 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
       }
 
       const points=rawPoints.map(pt=>{
-        const tStr=new Date(pt.time*1000).toISOString().substr(14,5);
         let quote="";
         if(pt.word) quote=` "${pt.word.trim()}"`;
         else if(words.length){
@@ -2224,7 +2224,27 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
           const nearest=words.reduce((a,b)=>Math.abs(b.start-mid)<Math.abs(a.start-mid)?b:a);
           if(Math.abs(nearest.start-mid)<=1.5) quote=` "${nearest.word.trim()}"`;
         }
-        return `${tStr}${quote} ${pt.msg}`;
+        const around=quote?` around${quote}`:"";
+        switch(pt.msg){
+          case 'speak louder':
+            return `Speak louder${around} to project confidence.`;
+          case 'speak softer':
+            return `Speak softer${around} to create contrast.`;
+          case 'add pitch variety':
+            return `Add pitch variety${around} to keep the audience engaged.`;
+          case 'steady your tone':
+            return `Steady your tone${around} for a smoother delivery.`;
+          case 'voice trembling':
+            return `Pause here${around} and steady your voice.`;
+          case 'enunciate words':
+            return `Pause and enunciate${around} for clarity.`;
+          case 'speaking too fast':
+            return `Slow down here${around} to let the message land.`;
+          case 'speaking too slow':
+            return `Speed up here${around} to maintain energy.`;
+          default:
+            return `${pt.msg}${around}.`;
+        }
       });
 
       const res={avgVolume:+db.toFixed(1),avgPitch:+avgPitch.toFixed(1),pitchVar:+pitchVar.toFixed(1),clarity:+clarityScore.toFixed(3),volRating,toneRating,clarityRating,tips:tips.join(' '),points};

--- a/index.html
+++ b/index.html
@@ -2220,15 +2220,18 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
       const merged=[];
       for(const pt of rawPoints){
         const last=merged[merged.length-1];
-        if(last && last.msg===pt.msg && pt.time-last.end<1){
+        if(last && pt.time-last.end<1){
           last.end=pt.time;
           if(pt.word) last.words.push(pt.word);
+          last.msgs.add(pt.msg);
         }else{
-          merged.push({msg:pt.msg,start:pt.time,end:pt.time,words:pt.word?[pt.word]:[]});
+          merged.push({start:pt.time,end:pt.time,words:pt.word?[pt.word]:[],msgs:new Set([pt.msg])});
         }
       }
+      const priority={'enunciate words':1,'voice trembling':2,'speaking too slow':3,'speaking too fast':4,'speak louder':5,'speak softer':6,'add pitch variety':7,'steady your tone':8};
+      const resolved=merged.map(g=>{const msgs=[...g.msgs].sort((a,b)=>(priority[a]||99)-(priority[b]||99));return {msg:msgs[0],start:g.start,end:g.end,words:g.words};});
 
-      const points=merged.map(group=>{
+      const points=resolved.map(group=>{
         let phrase="";
         if(group.words.length){
           phrase=group.words.map(w=>w.trim()).join(' ');


### PR DESCRIPTION
## Summary
- Generate persuasive voice tips including strategic pauses
- Provide sentence-level guidance without timestamps for notable voice moments

## Testing
- `python generate_sitemap.py`

------
https://chatgpt.com/codex/tasks/task_e_68bde30087cc833190b17a8c9100d619