### PR TITLE
Define isVeryShort to handle tiny transcripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1936,6 +1936,7 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
       conf.cats.forEach(c=>{ pack[c.key]=0; });
       return {buildScores(){return {cats:pack,total:0,metrics:bm,compare:{lexCos:0,biCos:0,mustHits:0,niceHits:0,mustTotal:0,niceTotal:0,struct:0,score:0},qm:qM,effWords}}};
     }
+    const isVeryShort=(effWords<10&&qM.qCount<2);
 
     const isOpen=type==='opening', isClose=type==='closing', isDir=type==='direct', isCross=type==='cross';
 


### PR DESCRIPTION
## Summary
- Prevent runtime errors by defining `isVeryShort` when scoring a transcript
- Cap scores at 25 for extremely short transcripts

## Testing
- `python3 -m py_compile generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68be05d1d5a483318f8aeb6765723e57