### PR TITLE
Fix argument scoring to evaluate user input

### DIFF
--- a/index.html
+++ b/index.html
@@ -1693,6 +1693,7 @@ function gptStopRecord(){
     // Build a USER-ONLY block that the judge must score
     const userOnly = gptChat
       .filter(m => m.role === 'user')
+      .slice(1)
       .map(m => `[USER]: ${m.content}`)
       .join('\n');
 


### PR DESCRIPTION
## Summary
- Ensure argument scoring evaluates only user-submitted lines by ignoring the initial scenario prompt.

## Testing
- `python -m py_compile generate_sitemap.py`

------
https://chatgpt.com/codex/tasks/task_e_68be2f84c3c08331900687bb95078318