### PR TITLE
Use Stripe payment link for subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ node server.js
    ```
    The response includes a Checkout `url` for the user to complete payment.
 
-The frontend demo page `subscription.html` interacts with the same endpoints and notes that free accounts get five prompts per month, while the paid plan is unlimited for $5 per month.
+The site now uses a Stripe payment link for subscriptions; visiting `subscription.html` redirects directly to the secure checkout for the $5/month unlimited plan.
 
 ## Notes
 - All API keys remain on the server; the frontend never sees them.

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@ a.inline{color:var(--accent);text-decoration:underline}
     <a class="tab" href="#rules" id="rulesTab">AZ Rules</a>
     <a class="tab" href="#quiz">Rules Quiz</a>
     <a class="tab" href="#howto">How To Use</a>
-    <a class="tab" href="subscription.html">Subscribe</a>
+    <a class="tab" href="https://buy.stripe.com/bJeaEX3Pz0NOadYe6r2cg00">Subscribe</a>
     <a class="tab" href="#contact">Contact</a>
   </nav>
 
@@ -150,7 +150,7 @@ a.inline{color:var(--accent);text-decoration:underline}
         <div class="choice">
           <h3>Option A — ChatGPT scoring (requires subscription)</h3>
           <p class="small">API keys are handled by MT academy. Subscribers get the most accurate scoring.</p>
-          <a href="subscription.html" class="btn primary" style="margin-right:8px">Subscribe</a>
+          <a href="https://buy.stripe.com/bJeaEX3Pz0NOadYe6r2cg00" class="btn primary" style="margin-right:8px">Subscribe</a>
           <button id="btnUseChatGPT" class="btn secondary">Use ChatGPT Scoring</button>
         </div>
         <div class="choice">

--- a/step-by-step-setup.md
+++ b/step-by-step-setup.md
@@ -46,8 +46,7 @@ Follow these instructions to run the subscription demo without exposing your API
   ```
   The server prints `Server running on 3000` when ready.
 
-## 6. Use the Demo Page
-- In your browser, open `subscription.html` from the project root.
-- Sign up, log in, send prompts, and upgrade plans via Stripe.
+## 6. Subscribe
+- Open `subscription.html` from the project root to be redirected to the Stripe checkout for the unlimited plan.
 
 Your API keys stay on the server; users never see them. When you want to deploy, set the same environment variables on your hosting provider.

--- a/subscription.html
+++ b/subscription.html
@@ -1,67 +1,12 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Subscription Demo</title>
+  <title>Redirecting...</title>
+  <meta http-equiv="refresh" content="0; url=https://buy.stripe.com/bJeaEX3Pz0NOadYe6r2cg00">
 </head>
 <body>
-  <h1>Subscription Demo</h1>
-  <section id="signup">
-    <h2>Sign Up</h2>
-    <input id="signupEmail" placeholder="Email">
-    <input id="signupPassword" placeholder="Password" type="password">
-    <button onclick="signup()">Sign Up</button>
-  </section>
-  <section id="login">
-    <h2>Login</h2>
-    <input id="loginEmail" placeholder="Email">
-    <input id="loginPassword" placeholder="Password" type="password">
-    <button onclick="login()">Login</button>
-    <p>Free accounts receive 5 prompts each month.</p>
-  </section>
-  <section id="prompt" style="display:none;">
-    <h2>Send Prompt</h2>
-    <textarea id="promptText"></textarea>
-    <button onclick="sendPrompt()">Send</button>
-    <pre id="promptResponse"></pre>
-  </section>
-  <section id="subscribe" style="display:none;">
-    <h2>Subscribe</h2>
-    <button onclick="subscribe()">Unlimited - $5/mo</button>
-  </section>
-<script>
-let userId=null;
-const API_BASE='http://localhost:3000';
-async function signup(){
-  const email=document.getElementById('signupEmail').value;
-  const password=document.getElementById('signupPassword').value;
-  const res=await fetch(`${API_BASE}/signup`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email,password})});
-  const data=await res.json();
-  alert(JSON.stringify(data));
-}
-async function login(){
-  const email=document.getElementById('loginEmail').value;
-  const password=document.getElementById('loginPassword').value;
-  const res=await fetch(`${API_BASE}/login`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email,password})});
-  const data=await res.json();
-  if(data.id){
-    userId=data.id;
-    document.getElementById('prompt').style.display='block';
-    document.getElementById('subscribe').style.display='block';
-  }
-  alert(JSON.stringify(data));
-}
-async function sendPrompt(){
-  const prompt=document.getElementById('promptText').value;
-  const res=await fetch(`${API_BASE}/prompt`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({userId,prompt})});
-  const data=await res.json();
-  document.getElementById('promptResponse').textContent=JSON.stringify(data);
-}
-async function subscribe(){
-  const res=await fetch(`${API_BASE}/subscribe`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({userId})});
-  const data=await res.json();
-  if(data.url) window.location=data.url; else alert(JSON.stringify(data));
-}
-</script>
+  <p>Redirecting to secure checkout…</p>
+  <p><a href="https://buy.stripe.com/bJeaEX3Pz0NOadYe6r2cg00">Click here if you are not redirected.</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Redirect subscription page to Stripe checkout and show fallback link.
- Update documentation to mention the Stripe payment link.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf894955808331a177e616bf3e5c2b