### PR TITLE
feat: add server-side gemini support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This project provides a minimal Express backend and demo frontend for a subscrip
    # edit .env to include real Stripe values
    ```
 2. The OpenAI key is stored in `backend/apikeys.js`. Replace the placeholder with your real key; the server reads it so users never see the key.
-3. Set these variables inside `backend/.env`:
+3. The Gemini key is stored in `backend/geminikey.js`. Replace the placeholder with your real Gemini API key.
+4. Set these variables inside `backend/.env`:
    - `STRIPE_SECRET` – secret key from your Stripe dashboard
    - `STRIPE_UNLIMITED_PRICE` – price ID for the $5/month unlimited plan
    - `EMAIL_HOST` – SMTP server host used to send confirmations
@@ -57,7 +58,13 @@ node server.js
      -H "Content-Type: application/json" \
      -d '{"userId":"<ID from login>","prompt":"hello"}'
    ```
-4. **Upgrade plan** via Stripe Checkout:
+4. **Send a Gemini prompt** (also limited for free plans):
+   ```bash
+   curl -X POST http://localhost:3000/gemini \
+     -H "Content-Type: application/json" \
+     -d '{"userId":"<ID from login>","prompt":"hello"}'
+   ```
+5. **Upgrade plan** via Stripe Checkout:
    ```bash
    curl -X POST http://localhost:3000/subscribe \
      -H "Content-Type: application/json" \

--- a/backend/geminikey.example.js
+++ b/backend/geminikey.example.js
@@ -1,0 +1,1 @@
+module.exports = 'PASTE_YOUR_GEMINI_API_KEY_HERE';

--- a/backend/geminikey.js
+++ b/backend/geminikey.js
@@ -1,0 +1,1 @@
+module.exports = 'PASTE_GEMINI_API_KEY_HERE';

--- a/subscription.html
+++ b/subscription.html
@@ -25,6 +25,12 @@
     <button onclick="sendPrompt()">Send</button>
     <pre id="promptResponse"></pre>
   </section>
+  <section id="geminiPrompt" style="display:none;">
+    <h2>Send Gemini Prompt</h2>
+    <textarea id="geminiPromptText"></textarea>
+    <button onclick="sendGemini()">Send</button>
+    <pre id="geminiPromptResponse"></pre>
+  </section>
   <section id="subscribe" style="display:none;">
     <h2>Subscribe</h2>
     <button onclick="subscribe()">Unlimited - $5/mo</button>
@@ -47,6 +53,7 @@ async function login(){
   if(data.id){
     userId=data.id;
     document.getElementById('prompt').style.display='block';
+    document.getElementById('geminiPrompt').style.display='block';
     document.getElementById('subscribe').style.display='block';
   }
   alert(JSON.stringify(data));
@@ -56,6 +63,12 @@ async function sendPrompt(){
   const res=await fetch(`${API_BASE}/prompt`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({userId,prompt})});
   const data=await res.json();
   document.getElementById('promptResponse').textContent=JSON.stringify(data);
+}
+async function sendGemini(){
+  const prompt=document.getElementById('geminiPromptText').value;
+  const res=await fetch(`${API_BASE}/gemini`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({userId,prompt})});
+  const data=await res.json();
+  document.getElementById('geminiPromptResponse').textContent=JSON.stringify(data);
 }
 async function subscribe(){
   window.location='https://buy.stripe.com/bJeaEX3Pz0NOadYe6r2cg00';


### PR DESCRIPTION
## Summary
- allow storing Gemini API key on the server via `backend/geminikey.js`
- add `/gemini` endpoint that proxies prompts to Google's Gemini API
- update demo frontend and docs to demonstrate Gemini usage

## Testing
- `npm test` *(fails: command not found)*
- `apt-get install -y nodejs npm` *(fails: Unable to locate package nodejs)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8cddc76083319972d7fd4f06bac6