### PR TITLE
Fix Subscribe nav to open Stripe checkout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2918,8 +2918,13 @@ document.addEventListener('DOMContentLoaded',()=>{
 
   document.querySelectorAll('#navMenu .tab').forEach(link=>{
     link.addEventListener('click',e=>{
+      const href = link.getAttribute('href') || '';
+      if(!href.startsWith('#')){
+        // External link (e.g., Stripe checkout) - allow default navigation
+        return;
+      }
       e.preventDefault();
-      showSection(link.getAttribute('href').slice(1));
+      showSection(href.slice(1));
       const nav=$('navMenu');
       nav.classList.remove('open');
       $('menuToggle').setAttribute('aria-expanded','false');


### PR DESCRIPTION
## Summary
- Allow external links in nav menu so Subscribe directs to Stripe checkout

## Testing
- `cd backend && npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf8f61e5108331bbbf1de70040d2d1