### PR TITLE
Email payment link on signup and simplify Stripe flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project provides a minimal Express backend and demo frontend for a subscrip
 3. The Gemini key is stored in `backend/geminikey.js`. Replace the placeholder with your real Gemini API key.
 4. Set these variables inside `backend/.env`:
    - `STRIPE_SECRET` – secret key from your Stripe dashboard
-   - `STRIPE_UNLIMITED_PRICE` – price ID for the $5/month unlimited plan
+   - `STRIPE_ENDPOINT_SECRET` – webhook signing secret for checkout events
    - `EMAIL_HOST` – SMTP server host used to send confirmations
    - `EMAIL_PORT` – SMTP port (e.g., 587)
    - `EMAIL_USER` – SMTP username
@@ -46,6 +46,7 @@ node server.js
      -H "Content-Type: application/json" \
      -d '{"email":"test@example.com","password":"secret"}'
    ```
+   The server emails a Stripe payment link so new users can upgrade when ready.
 2. **Login** to retrieve the user ID and plan:
    ```bash
    curl -X POST http://localhost:3000/login \
@@ -64,13 +65,13 @@ node server.js
      -H "Content-Type: application/json" \
      -d '{"userId":"<ID from login>","prompt":"hello"}'
    ```
-5. **Upgrade plan** via Stripe Checkout:
+5. **Upgrade plan** via Stripe payment link:
    ```bash
    curl -X POST http://localhost:3000/subscribe \
      -H "Content-Type: application/json" \
      -d '{"userId":"<ID from login>"}'
    ```
-   The response includes a Checkout `url` for the user to complete payment.
+   The response contains a `url` field with the hosted Stripe Checkout page.
 
 The frontend demo page `subscription.html` interacts with the same endpoints and notes that free accounts get five prompts per month, while the paid plan is unlimited for $5 per month.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,5 @@
 STRIPE_SECRET=sk_test_placeholder
-STRIPE_UNLIMITED_PRICE=price_unlimited_id
+STRIPE_ENDPOINT_SECRET=whsec_placeholder
 EMAIL_HOST=smtp.example.com
 EMAIL_PORT=587
 EMAIL_USER=username

--- a/step-by-step-setup.md
+++ b/step-by-step-setup.md
@@ -6,7 +6,7 @@ Follow these instructions to run the subscription demo without exposing your API
 - [Install Node.js](https://nodejs.org/) version 18 or newer.
 - Create accounts and obtain keys for:
   - **OpenAI** – gives you an API key.
-  - **Stripe** – create one $5/month subscription product for unlimited prompts to get a price ID.
+  - **Stripe** – you'll need a secret key and webhook signing secret.
 
 ## 2. Download the Project
 - Download or clone this repository and open a terminal in the project folder.
@@ -28,7 +28,7 @@ Follow these instructions to run the subscription demo without exposing your API
 4. Open the new `.env` file in a text editor and replace the placeholders:
    ```ini
    STRIPE_SECRET=PASTE_YOUR_STRIPE_SECRET_HERE
-   STRIPE_UNLIMITED_PRICE=PASTE_PRICE_ID_HERE
+   STRIPE_ENDPOINT_SECRET=PASTE_ENDPOINT_SECRET_HERE
    ```
    > **Important:** Keep `apikeys.js` and `.env` private; never share or commit them.
 


### PR DESCRIPTION
## Summary
- send an email with a preconfigured Stripe payment link during signup
- expose static Stripe Checkout link from `/subscribe`
- document and env sample updated for new Stripe webhook secret

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf9d003c988331b7fa3999f857a2d5