### PR TITLE
Integrate Stripe Checkout and persist subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This project provides a minimal Express backend and demo frontend for a subscrip
 4. Set these variables inside `backend/.env`:
    - `STRIPE_SECRET` – secret key from your Stripe dashboard
    - `STRIPE_ENDPOINT_SECRET` – webhook signing secret for checkout events
+   - `STRIPE_PRICE_ID` – price ID for the subscription product
+   - `STRIPE_SUCCESS_URL` – URL users return to after successful checkout
+   - `STRIPE_CANCEL_URL` – URL users return to if they cancel checkout
    - `EMAIL_HOST` – SMTP server host used to send confirmations
    - `EMAIL_PORT` – SMTP port (e.g., 587)
    - `EMAIL_USER` – SMTP username
@@ -65,7 +68,11 @@ node server.js
      -H "Content-Type: application/json" \
      -d '{"userId":"<ID from login>","prompt":"hello"}'
    ```
-5. **Upgrade plan** via Stripe payment link:
+5. **Check current plan**:
+   ```bash
+   curl http://localhost:3000/plan/<ID from login>
+   ```
+6. **Upgrade plan** via Stripe Checkout:
    ```bash
    curl -X POST http://localhost:3000/subscribe \
      -H "Content-Type: application/json" \

--- a/backend/server.test.js
+++ b/backend/server.test.js
@@ -19,6 +19,12 @@ const app = require('./server');
   }
   console.log('login plan test passed');
 
+  const planCheck = await request(app).get(`/plan/${userId}`);
+  if (planCheck.body.plan !== 'free') {
+    throw new Error('plan endpoint should return free');
+  }
+  console.log('plan endpoint test passed');
+
   for (let i = 0; i < 5; i++) {
     const res = await request(app).post('/prompt').send({ userId, prompt: 'hi' });
     if (res.status !== 200) {

--- a/subscription.html
+++ b/subscription.html
@@ -36,13 +36,37 @@
     <button onclick="subscribe()">Unlimited - $5/mo</button>
   </section>
 <script>
-let userId=null;
+let userId=localStorage.getItem('userId');
+let plan=localStorage.getItem('plan');
 // Default to the local API when developing on localhost or from the file system.
 // Otherwise, talk to the same origin that served this page so hosted setups work
 // without hitting the user's machine (which causes "Failed to fetch" errors).
 const API_BASE=(location.hostname==='localhost'||location.hostname==='')
   ?'http://localhost:3000'
   :location.origin;
+
+if(userId){
+  document.getElementById('prompt').style.display='block';
+  document.getElementById('geminiPrompt').style.display='block';
+  refreshPlan();
+}
+
+async function refreshPlan(){
+  if(!userId)return;
+  try{
+    const res=await fetch(`${API_BASE}/plan/${userId}`);
+    const data=await res.json();
+    plan=data.plan;
+    localStorage.setItem('plan',plan);
+    if(plan==='unlimited'){
+      document.getElementById('subscribe').style.display='none';
+    }else{
+      document.getElementById('subscribe').style.display='block';
+    }
+  }catch(e){
+    // ignore
+  }
+}
 async function signup(){
   const email=document.getElementById('signupEmail').value;
   const password=document.getElementById('signupPassword').value;
@@ -65,17 +89,20 @@ async function login(){
   const email=document.getElementById('loginEmail').value;
   const password=document.getElementById('loginPassword').value;
   try{
-    const res=await fetch(`${API_BASE}/login`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email,password})});
+    const res=await fetch(`${API_BASE}/login`,{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({email,password})
+    });
     const data=await res.json();
     if(res.ok&&data.id){
       userId=data.id;
+      plan=data.plan;
+      localStorage.setItem('userId',userId);
+      localStorage.setItem('plan',plan);
       document.getElementById('prompt').style.display='block';
       document.getElementById('geminiPrompt').style.display='block';
-      if(data.plan==='unlimited'){
-        document.getElementById('subscribe').style.display='none';
-      }else{
-        document.getElementById('subscribe').style.display='block';
-      }
+      await refreshPlan();
       alert(`Logged in as ${data.plan} user.`);
     }else{
       alert(data.error||'Login failed');


### PR DESCRIPTION
## Summary
- Replace static payment links with dynamic Stripe Checkout sessions for signups and subscription upgrades
- Add `/plan/:userId` endpoint and frontend localStorage to recognize returning subscribers without re-login
- Document new Stripe environment variables and extend tests for plan endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfa33232708331afe9d9ff8fcdefcb