### PR TITLE
Simplify signup and subscription with Stripe buy button

### DIFF
--- a/subscription.html
+++ b/subscription.html
@@ -31,9 +31,13 @@
     <button onclick="sendGemini()">Send</button>
     <pre id="geminiPromptResponse"></pre>
   </section>
-  <section id="subscribe" style="display:none;">
+  <section id="subscribeSection" style="display:none;">
     <h2>Subscribe</h2>
-    <button onclick="subscribe()">Unlimited - $5/mo</button>
+    <script async src="https://js.stripe.com/v3/buy-button.js"></script>
+    <stripe-buy-button
+      buy-button-id="buy_btn_1S5IkRGjcFtLGwutsPk8XnpU"
+      publishable-key="pk_live_51S5Ea6GjcFtLGwutrmUh3W6qKpvIhv0pqpEmnZXyrsIkmSOqszyxyClM7WQCRdvVotLQI6RMtbHjrxIy2kgG0Gc900ElUoV6yb">
+    </stripe-buy-button>
   </section>
 <script>
 let userId=localStorage.getItem('userId');
@@ -59,9 +63,9 @@ async function refreshPlan(){
     plan=data.plan;
     localStorage.setItem('plan',plan);
     if(plan==='unlimited'){
-      document.getElementById('subscribe').style.display='none';
+      document.getElementById('subscribeSection').style.display='none';
     }else{
-      document.getElementById('subscribe').style.display='block';
+      document.getElementById('subscribeSection').style.display='block';
     }
   }catch(e){
     // ignore
@@ -78,10 +82,7 @@ async function signup(){
     });
     const data=await res.json();
     if(res.ok){
-      alert('Signup successful! Check your email for the payment link.');
-      if(data.paymentLink){
-        window.open(data.paymentLink,'_blank');
-      }
+      alert('Signup successful! Check your email for next steps.');
     }else{
       alert(data.error||'Signup failed');
     }
@@ -134,19 +135,6 @@ async function sendGemini(){
   });
   const data=await res.json();
   document.getElementById('geminiPromptResponse').textContent=JSON.stringify(data);
-}
-async function subscribe(){
-  const res = await fetch(`${API_BASE}/subscribe`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ userId })
-  });
-  const data = await res.json();
-  if (data.url) {
-    window.location = data.url;
-  } else {
-    alert('Subscription failed: ' + (data.error || 'Unknown error'));
-  }
 }
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Send welcome email on signup without generating payment link
- Upgrade users via webhook by matching Stripe session email
- Replace custom subscribe button with Stripe buy button snippet

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfa892ebe08331ac8d72440ffdeaea