### PR TITLE
Define isVeryShort to prevent scoring errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1940,6 +1940,7 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
       return {buildScores(){return {cats:pack,total:0,metrics:bm,compare:{lexCos:0,biCos:0,mustHits:0,niceHits:0,mustTotal:0,niceTotal:0,struct:0,score:0},qm:qM,effWords}}};
     }
 
+    const isVeryShort = (effWords < 10 && qM.qCount < 2);
     const isOpen=type==='opening', isClose=type==='closing', isDir=type==='direct', isCross=type==='cross';
 
     let delivery=6;


### PR DESCRIPTION
## Summary
- Define `isVeryShort` flag based on word and question counts
- Use flag to cap score totals for extremely short transcripts

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfad1c252083319782e7284fd6a351