### PR TITLE
Inline very short transcript cap to avoid scoring error

### DIFF
--- a/index.html
+++ b/index.html
@@ -2020,7 +2020,7 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
     }
 
     let total=0; conf.cats.forEach(c=>{ total+=clamp(pack[c.key],1,10)*(c.w*10) }); total=Math.round(total);
-    if(isVeryShort) total=Math.min(total,25);
+    if(effWords<10 && qM.qCount<2) total=Math.min(total,25);
 
     return {buildScores(){return {cats:pack,total,metrics:bm,compare:cmp,qm:qM,effWords}}};
   }


### PR DESCRIPTION
## Summary
- Inline check for very short transcripts to cap total without using undefined flag

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfad1c252083319782e7284fd6a351