### PR TITLE
Define short-transcript flag to guard scoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -1934,6 +1934,7 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
 
     const effWords=effectiveWordCount(text);
     const noSpeech = isEffectivelyEmpty(text) || effWords < 5;
+    const isVeryShort = effWords < 10 && qM.qCount < 2;
     if(noSpeech){
       const conf=RUBRICS[type]; const pack={};
       conf.cats.forEach(c=>{ pack[c.key]=0; });


### PR DESCRIPTION
## Summary
- Explicitly declare `isVeryShort` to avoid undefined variable errors in scoring
- Cap total score to 25 when transcripts are extremely short

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfad1c252083319782e7284fd6a351