### PR TITLE
fix duplicate isVeryShort declaration in scoring logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -1941,7 +1941,6 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
       return {buildScores(){return {cats:pack,total:0,metrics:bm,compare:{lexCos:0,biCos:0,mustHits:0,niceHits:0,mustTotal:0,niceTotal:0,struct:0,score:0},qm:qM,effWords}}};
     }
 
-    const isVeryShort = (effWords < 10 && qM.qCount < 2);
     const isOpen=type==='opening', isClose=type==='closing', isDir=type==='direct', isCross=type==='cross';
 
     let delivery=6;


### PR DESCRIPTION
## Summary
- remove redundant `isVeryShort` constant in `score` function to prevent runtime syntax error

## Testing
- `python -m py_compile generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68c02638fe8883318fff0ed27013bbe0