### PR TITLE
Auto-enable ChatGPT scoring when API key present

### DIFF
--- a/index.html
+++ b/index.html
@@ -1009,6 +1009,11 @@ EngineState = {
   set geminiModel(v){ save('mtpl.geminiModel', v||'gemini-1.5-flash') }
 };
 
+if (EngineState.openaiKey && EngineState.mode !== 'chatgpt') {
+  EngineState.mode = 'chatgpt';
+}
+renderModeBadge();
+
 function renderModeBadge(){
   const b=$('modeBadge'), banner=$('videoModeBanner');
   if(!b) return;


### PR DESCRIPTION
## Summary
- Enable ChatGPT scoring automatically when a stored OpenAI key is detected
- Render scoring mode badge on load so the UI reflects current engine state

## Testing
- `python -m py_compile generate_sitemap.py`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c02842e23c833182621e6fe3d4311a