### PR TITLE
Clarify API key setup instructions

### DIFF
--- a/api-keys.html
+++ b/api-keys.html
@@ -12,10 +12,10 @@
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=./#keys">
   <title>API Keys / Engine – MT academy</title>
-  <meta name="description" content="Links to create OpenAI and Gemini API keys and choose models for MT academy.">
+  <meta name="description" content="Step-by-step setup for OpenAI (funds required) and Gemini (credit card required) API keys and model selection for MT academy.">
 </head>
 <body>
   <h1>API Keys / Engine</h1>
-  <p>Manage your keys on the <a href="./#keys">main MT academy page</a>.</p>
+  <p>OpenAI keys need funds deposited and Gemini keys require a linked credit card. Manage your keys on the <a href="./#keys">main MT academy page</a>.</p>
 </body>
 </html>

--- a/howto.html
+++ b/howto.html
@@ -12,11 +12,11 @@
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=./#howto">
   <title>How to Use MT academy</title>
-  <meta name="description" content="Quick guide for the Objections, Video Coach, Writing, Rules, Rules Quiz, and API key setup including Gemini.">
+  <meta name="description" content="Step-by-step guide for Objections, Video Coach, Writing, Rules, Rules Quiz, and setting up OpenAI (funds required) and Gemini (credit card required) API keys.">
 </head>
 <body>
   <h1>How to Use</h1>
-  <p>Quick tips for MT academy's practice tools and API key setup.</p>
+  <p>Quick tips for MT academy's practice tools and API key setup. OpenAI keys need funds on the account, and Gemini keys must be linked to a credit card.</p>
   <p>See the full instructions on the <a href="./#howto">main page</a>.</p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -150,7 +150,9 @@ a.inline{color:var(--accent);text-decoration:underline}
         <div class="choice">
           <h3>Option A — Use my ChatGPT account (recommended)</h3>
           <ol class="small" style="margin-top:6px">
-            <li>Go to <strong>platform.openai.com</strong> → API keys → create a key.</li>
+            <li>Visit <strong>platform.openai.com</strong> and sign in.</li>
+            <li>Open <strong>Billing</strong> → <strong>Add payment method</strong> and deposit funds.</li>
+            <li>Go to <strong>API keys</strong> → <strong>Create new secret key</strong>.</li>
             <li>Paste the key below. It is stored only in your browser (LocalStorage).</li>
             <li>Select a model. “gpt-4o” is recommended.</li>
           </ol>
@@ -182,7 +184,9 @@ a.inline{color:var(--accent);text-decoration:underline}
         <div class="choice">
           <h3>Movement Scoring</h3>
           <ol class="small" style="margin-top:6px">
-            <li>Visit <strong>ai.google.dev</strong> → API keys → create a key.</li>
+            <li>Visit <strong>ai.google.dev</strong> and sign in.</li>
+            <li>Create or select a project, then link a billing account with a credit card.</li>
+            <li>Go to <strong>API keys</strong> → <strong>Create API key</strong>.</li>
             <li>Paste the key below. Stored only in your browser.</li>
           </ol>
           <label class="small">Gemini API Key
@@ -341,7 +345,9 @@ a.inline{color:var(--accent);text-decoration:underline}
       <div class="choice">
         <h3>ChatGPT Scoring</h3>
         <ol class="small" style="margin-top:6px">
-          <li>Go to <strong>platform.openai.com</strong> &rarr; API keys &rarr; create a key.</li>
+          <li>Visit <strong>platform.openai.com</strong> and sign in.</li>
+          <li>Open <strong>Billing</strong> → <strong>Add payment method</strong> and deposit funds.</li>
+          <li>Go to <strong>API keys</strong> → <strong>Create new secret key</strong>.</li>
           <li>Paste the key below and choose a model.</li>
         </ol>
         <label class="small">OpenAI API Key
@@ -365,7 +371,9 @@ a.inline{color:var(--accent);text-decoration:underline}
       <div class="choice">
         <h3>Movement Scoring</h3>
         <ol class="small" style="margin-top:6px">
-          <li>Visit <strong>ai.google.dev</strong> &rarr; API keys &rarr; create a key.</li>
+          <li>Visit <strong>ai.google.dev</strong> and sign in.</li>
+          <li>Create or select a project, then link a billing account with a credit card.</li>
+          <li>Go to <strong>API keys</strong> → <strong>Create API key</strong>.</li>
           <li>Paste the key below and choose a model.</li>
         </ol>
         <label class="small">Gemini API Key
@@ -435,7 +443,7 @@ a.inline{color:var(--accent);text-decoration:underline}
         </ul>
       </li>
     </ul>
-    <p class="small">Need help with API keys? Go to the API Keys page to upload your API key.</p>
+    <p class="small">To use ChatGPT or Gemini features, create your own API keys. OpenAI keys require prepaid funds, and Gemini keys need a linked credit card. See the API Keys page for step-by-step setup.</p>
   </section>
   <!-- Contact -->
   <section id="contact" class="card">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,11 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mocktrialacademy.com/</loc>
-    <lastmod>2025-09-13</lastmod>
+    <lastmod>2025-09-12</lastmod>
   </url>
   <url>
     <loc>https://mocktrialacademy.com/api-keys.html</loc>
-    <lastmod>2025-09-13</lastmod>
+    <lastmod>2025-09-12</lastmod>
   </url>
   <url>
     <loc>https://mocktrialacademy.com/contact.html</loc>


### PR DESCRIPTION
## Summary
- Detail OpenAI API key steps, including signing in, adding a payment method, depositing funds, and creating a key.
- Explain Gemini API key setup with project selection and linking a credit-card-backed billing account before generating a key.
- Update How to Use section to note funding requirements for ChatGPT and credit card linkage for Gemini.

## Testing
- `python generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68c62b802bb08331aa11618efece7ecd