### PR TITLE
Enhance SEO metadata and sitemap

### DIFF
--- a/api-keys.html
+++ b/api-keys.html
@@ -13,6 +13,35 @@
   <meta http-equiv="refresh" content="0; url=./#keys">
   <title>API Keys / Engine – MT academy</title>
   <meta name="description" content="Step-by-step setup for OpenAI (funds required) and Gemini (credit card required) API keys and model selection for MT academy.">
+  <meta name="keywords" content="mock trial, mock trial practice, mock trial resources, mock trial quizzes, high school mock trial, mock trial coaching, mock trial competition, MT academy">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://mocktrialacademy.com/api-keys.html">
+  <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
+  <meta property="og:title" content="API Keys / Engine – MT academy">
+  <meta property="og:description" content="Step-by-step setup for OpenAI (funds required) and Gemini (credit card required) API keys and model selection for MT academy.">
+  <meta property="og:url" content="https://mocktrialacademy.com/api-keys.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="MT academy">
+  <meta property="og:locale" content="en_US">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "API Keys / Engine – MT academy",
+    "url": "https://mocktrialacademy.com/api-keys.html",
+    "description": "Step-by-step setup for OpenAI (funds required) and Gemini (credit card required) API keys and model selection for MT academy.",
+    "keywords": [
+      "mock trial",
+      "mock trial practice",
+      "mock trial resources",
+      "mock trial quizzes",
+      "high school mock trial",
+      "mock trial coaching",
+      "mock trial competition",
+      "MT academy"
+    ]
+  }
+  </script>
 </head>
 <body>
   <h1>API Keys / Engine</h1>

--- a/contact.html
+++ b/contact.html
@@ -13,6 +13,35 @@
   <meta http-equiv="refresh" content="0; url=./#contact">
   <title>Contact MT academy</title>
   <meta name="description" content="Get in touch with MT academy for support or inquiries.">
+  <meta name="keywords" content="mock trial, mock trial practice, mock trial resources, mock trial quizzes, high school mock trial, mock trial coaching, mock trial competition, MT academy">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://mocktrialacademy.com/contact.html">
+  <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
+  <meta property="og:title" content="Contact MT academy">
+  <meta property="og:description" content="Get in touch with MT academy for support or inquiries.">
+  <meta property="og:url" content="https://mocktrialacademy.com/contact.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="MT academy">
+  <meta property="og:locale" content="en_US">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Contact MT academy",
+    "url": "https://mocktrialacademy.com/contact.html",
+    "description": "Get in touch with MT academy for support or inquiries.",
+    "keywords": [
+      "mock trial",
+      "mock trial practice",
+      "mock trial resources",
+      "mock trial quizzes",
+      "high school mock trial",
+      "mock trial coaching",
+      "mock trial competition",
+      "MT academy"
+    ]
+  }
+  </script>
 </head>
 <body>
   <h1>Contact</h1>

--- a/generate_sitemap.py
+++ b/generate_sitemap.py
@@ -32,8 +32,13 @@ def build_urls(root: Path):
         loc = BASE_URL + "/" + path.relative_to(root).as_posix()
         if path.name == "index.html":
             loc = BASE_URL + "/"
+            priority = "1.0"
+            changefreq = "weekly"
+        else:
+            priority = "0.8"
+            changefreq = "monthly"
         mtime = lastmod_from_git(path)
-        urls.append((loc, mtime))
+        urls.append((loc, mtime, priority, changefreq))
     urls.sort(key=lambda x: x[0])
     return urls
 
@@ -42,10 +47,12 @@ def write_sitemap(urls, outfile: Path):
     with outfile.open("w", encoding="utf-8") as f:
         f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
         f.write('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n')
-        for loc, mtime in urls:
+        for loc, mtime, priority, changefreq in urls:
             f.write("  <url>\n")
             f.write(f"    <loc>{loc}</loc>\n")
             f.write(f"    <lastmod>{mtime.date().isoformat()}</lastmod>\n")
+            f.write(f"    <changefreq>{changefreq}</changefreq>\n")
+            f.write(f"    <priority>{priority}</priority>\n")
             f.write("  </url>\n")
         f.write('</urlset>\n')
 

--- a/howto.html
+++ b/howto.html
@@ -13,6 +13,35 @@
   <meta http-equiv="refresh" content="0; url=./#howto">
   <title>How to Use MT academy</title>
   <meta name="description" content="Step-by-step guide for Objections, Video Coach, Writing, Rules, Rules Quiz, and setting up OpenAI (funds required) and Gemini (credit card required) API keys.">
+  <meta name="keywords" content="mock trial, mock trial practice, mock trial resources, mock trial quizzes, high school mock trial, mock trial coaching, mock trial competition, MT academy">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://mocktrialacademy.com/howto.html">
+  <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
+  <meta property="og:title" content="How to Use MT academy">
+  <meta property="og:description" content="Step-by-step guide for Objections, Video Coach, Writing, Rules, Rules Quiz, and setting up OpenAI (funds required) and Gemini (credit card required) API keys.">
+  <meta property="og:url" content="https://mocktrialacademy.com/howto.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="MT academy">
+  <meta property="og:locale" content="en_US">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "How to Use MT academy",
+    "url": "https://mocktrialacademy.com/howto.html",
+    "description": "Step-by-step guide for Objections, Video Coach, Writing, Rules, Rules Quiz, and setting up OpenAI (funds required) and Gemini (credit card required) API keys.",
+    "keywords": [
+      "mock trial",
+      "mock trial practice",
+      "mock trial resources",
+      "mock trial quizzes",
+      "high school mock trial",
+      "mock trial coaching",
+      "mock trial competition",
+      "MT academy"
+    ]
+  }
+  </script>
 </head>
 <body>
   <h1>How to Use</h1>

--- a/objections.html
+++ b/objections.html
@@ -13,6 +13,35 @@
   <meta http-equiv="refresh" content="0; url=./#objections">
   <title>Objections Drill – MT academy</title>
   <meta name="description" content="Practice mock trial objections with MT academy's interactive drill.">
+  <meta name="keywords" content="mock trial, mock trial practice, mock trial resources, mock trial quizzes, high school mock trial, mock trial coaching, mock trial competition, MT academy">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://mocktrialacademy.com/objections.html">
+  <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
+  <meta property="og:title" content="Objections Drill – MT academy">
+  <meta property="og:description" content="Practice mock trial objections with MT academy's interactive drill.">
+  <meta property="og:url" content="https://mocktrialacademy.com/objections.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="MT academy">
+  <meta property="og:locale" content="en_US">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Objections Drill – MT academy",
+    "url": "https://mocktrialacademy.com/objections.html",
+    "description": "Practice mock trial objections with MT academy's interactive drill.",
+    "keywords": [
+      "mock trial",
+      "mock trial practice",
+      "mock trial resources",
+      "mock trial quizzes",
+      "high school mock trial",
+      "mock trial coaching",
+      "mock trial competition",
+      "MT academy"
+    ]
+  }
+  </script>
 </head>
 <body>
   <h1>Objections Drill</h1>

--- a/quiz.html
+++ b/quiz.html
@@ -13,6 +13,35 @@
   <meta http-equiv="refresh" content="0; url=./#quiz">
   <title>Rules Quiz – MT academy</title>
   <meta name="description" content="Test your knowledge of mock trial rules with MT academy's quiz.">
+  <meta name="keywords" content="mock trial, mock trial practice, mock trial resources, mock trial quizzes, high school mock trial, mock trial coaching, mock trial competition, MT academy">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://mocktrialacademy.com/quiz.html">
+  <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
+  <meta property="og:title" content="Rules Quiz – MT academy">
+  <meta property="og:description" content="Test your knowledge of mock trial rules with MT academy's quiz.">
+  <meta property="og:url" content="https://mocktrialacademy.com/quiz.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="MT academy">
+  <meta property="og:locale" content="en_US">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Rules Quiz – MT academy",
+    "url": "https://mocktrialacademy.com/quiz.html",
+    "description": "Test your knowledge of mock trial rules with MT academy's quiz.",
+    "keywords": [
+      "mock trial",
+      "mock trial practice",
+      "mock trial resources",
+      "mock trial quizzes",
+      "high school mock trial",
+      "mock trial coaching",
+      "mock trial competition",
+      "MT academy"
+    ]
+  }
+  </script>
 </head>
 <body>
   <h1>Rules Quiz</h1>

--- a/rules.html
+++ b/rules.html
@@ -13,6 +13,35 @@
   <meta http-equiv="refresh" content="0; url=./#rules">
   <title>Rules of Evidence Explorer – MT academy</title>
   <meta name="description" content="Browse the Arizona High School Mock Trial Rules of Evidence with explanations.">
+  <meta name="keywords" content="mock trial, mock trial practice, mock trial resources, mock trial quizzes, high school mock trial, mock trial coaching, mock trial competition, MT academy">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://mocktrialacademy.com/rules.html">
+  <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
+  <meta property="og:title" content="Rules of Evidence Explorer – MT academy">
+  <meta property="og:description" content="Browse the Arizona High School Mock Trial Rules of Evidence with explanations.">
+  <meta property="og:url" content="https://mocktrialacademy.com/rules.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="MT academy">
+  <meta property="og:locale" content="en_US">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Rules of Evidence Explorer – MT academy",
+    "url": "https://mocktrialacademy.com/rules.html",
+    "description": "Browse the Arizona High School Mock Trial Rules of Evidence with explanations.",
+    "keywords": [
+      "mock trial",
+      "mock trial practice",
+      "mock trial resources",
+      "mock trial quizzes",
+      "high school mock trial",
+      "mock trial coaching",
+      "mock trial competition",
+      "MT academy"
+    ]
+  }
+  </script>
 </head>
 <body>
   <h1>AZ HS Mock Trial Rules of Evidence</h1>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,38 +2,56 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mocktrialacademy.com/</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mocktrialacademy.com/api-keys.html</loc>
-    <lastmod>2025-09-12</lastmod>
+    <lastmod>2025-09-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mocktrialacademy.com/contact.html</loc>
-    <lastmod>2025-09-04</lastmod>
+    <lastmod>2025-09-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mocktrialacademy.com/howto.html</loc>
-    <lastmod>2025-09-06</lastmod>
+    <lastmod>2025-09-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mocktrialacademy.com/objections.html</loc>
-    <lastmod>2025-09-04</lastmod>
+    <lastmod>2025-09-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mocktrialacademy.com/quiz.html</loc>
-    <lastmod>2025-09-04</lastmod>
+    <lastmod>2025-09-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mocktrialacademy.com/rules.html</loc>
-    <lastmod>2025-09-04</lastmod>
+    <lastmod>2025-09-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mocktrialacademy.com/video-coach.html</loc>
-    <lastmod>2025-09-06</lastmod>
+    <lastmod>2025-09-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mocktrialacademy.com/writing.html</loc>
-    <lastmod>2025-09-04</lastmod>
+    <lastmod>2025-09-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
 </urlset>

--- a/video-coach.html
+++ b/video-coach.html
@@ -13,6 +13,35 @@
   <meta http-equiv="refresh" content="0; url=./#video">
   <title>Video Coach – MT academy</title>
   <meta name="description" content="Record, transcribe, score, and analyze movement with MT academy's Video Coach.">
+  <meta name="keywords" content="mock trial, mock trial practice, mock trial resources, mock trial quizzes, high school mock trial, mock trial coaching, mock trial competition, MT academy">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://mocktrialacademy.com/video-coach.html">
+  <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
+  <meta property="og:title" content="Video Coach – MT academy">
+  <meta property="og:description" content="Record, transcribe, score, and analyze movement with MT academy's Video Coach.">
+  <meta property="og:url" content="https://mocktrialacademy.com/video-coach.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="MT academy">
+  <meta property="og:locale" content="en_US">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Video Coach – MT academy",
+    "url": "https://mocktrialacademy.com/video-coach.html",
+    "description": "Record, transcribe, score, and analyze movement with MT academy's Video Coach.",
+    "keywords": [
+      "mock trial",
+      "mock trial practice",
+      "mock trial resources",
+      "mock trial quizzes",
+      "high school mock trial",
+      "mock trial coaching",
+      "mock trial competition",
+      "MT academy"
+    ]
+  }
+  </script>
 </head>
 <body>
   <h1>Video Coach</h1>

--- a/writing.html
+++ b/writing.html
@@ -13,6 +13,35 @@
   <meta http-equiv="refresh" content="0; url=./#writing">
   <title>Writing New Materials – MT academy</title>
   <meta name="description" content="Generate mock trial materials and prompts using MT academy's writing tools.">
+  <meta name="keywords" content="mock trial, mock trial practice, mock trial resources, mock trial quizzes, high school mock trial, mock trial coaching, mock trial competition, MT academy">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://mocktrialacademy.com/writing.html">
+  <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
+  <meta property="og:title" content="Writing New Materials – MT academy">
+  <meta property="og:description" content="Generate mock trial materials and prompts using MT academy's writing tools.">
+  <meta property="og:url" content="https://mocktrialacademy.com/writing.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="MT academy">
+  <meta property="og:locale" content="en_US">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Writing New Materials – MT academy",
+    "url": "https://mocktrialacademy.com/writing.html",
+    "description": "Generate mock trial materials and prompts using MT academy's writing tools.",
+    "keywords": [
+      "mock trial",
+      "mock trial practice",
+      "mock trial resources",
+      "mock trial quizzes",
+      "high school mock trial",
+      "mock trial coaching",
+      "mock trial competition",
+      "MT academy"
+    ]
+  }
+  </script>
 </head>
 <body>
   <h1>Writing New Materials</h1>


### PR DESCRIPTION
## Summary
- Format JSON-LD keyword lists on standalone pages for cleaner structured data.
- Regenerate sitemap to reflect updated pages with changefreq and priority fields.

## Testing
- `python generate_sitemap.py`
- `python -m py_compile generate_sitemap.py`


------
https://chatgpt.com/codex/tasks/task_e_68c62c87f9fc833181a7b59f606bbea6