### PR TITLE
Let the proxy read API keys from a local private file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and paste your real keys on the right side.
+# Example:
+# OPENAI_API_KEY=sk-your-key-here
+# GEMINI_API_KEY=your-gemini-key
+
+OPENAI_API_KEY=sk-your-openai-key-here
+GEMINI_API_KEY=your-gemini-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# MT academy
+
+Welcome! This project already knows how to talk to OpenAI and Gemini for you—all you need to do is paste your keys in one spot.
+
+## 1. Paste your keys (one time)
+1. Open `server/private-keys.js` in any text editor.
+2. Replace the placeholder strings with your real OpenAI and Gemini keys. Keep the quotes around each key. If you are not using Gemini yet, leave that value as an empty string (`''`).
+3. Save the file. The keys stay on the server side and are never sent to the browser.
+
+## 2. Run the site locally
+1. In a terminal inside this folder run:
+   ```bash
+   npm install
+   ```
+2. After the install finishes, start the server:
+   ```bash
+   npm start
+   ```
+3. Visit <http://localhost:3000> while the terminal stays open. The server will proxy all AI calls with the keys you saved.
+
+## Optional: `.env` support
+If you prefer environment variables, you can still create a `.env` file with `OPENAI_API_KEY=` and `GEMINI_API_KEY=` entries. The server will use `.env` values first and fall back to `server/private-keys.js` when they are missing.

--- a/api-keys.html
+++ b/api-keys.html
@@ -11,8 +11,8 @@
   </script>
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=./#keys">
-  <title>API Keys / Engine – MT academy</title>
-  <meta name="description" content="Step-by-step setup for OpenAI (funds required) and Gemini (credit card required) API keys and model selection for MT academy.">
+  <title>AI Access – MT academy</title>
+  <meta name="description" content="Overview of MT academy’s managed OpenAI and Gemini access—no setup required.">
   <meta name="keywords" content="mock trial, mock trial practice, mock trial resources, mock trial quizzes, high school mock trial, mock trial coaching, mock trial competition, MT academy">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://mocktrialacademy.com/api-keys.html">
@@ -20,8 +20,8 @@
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="shortcut icon" href="/favicon.svg" type="image/svg+xml">
   <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
-  <meta property="og:title" content="API Keys / Engine – MT academy">
-  <meta property="og:description" content="Step-by-step setup for OpenAI (funds required) and Gemini (credit card required) API keys and model selection for MT academy.">
+  <meta property="og:title" content="AI Access – MT academy">
+  <meta property="og:description" content="Overview of MT academy’s managed OpenAI and Gemini access—no setup required.">
   <meta property="og:url" content="https://mocktrialacademy.com/api-keys.html">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="MT academy">
@@ -30,9 +30,9 @@
   {
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "name": "API Keys / Engine – MT academy",
+    "name": "AI Access – MT academy",
     "url": "https://mocktrialacademy.com/api-keys.html",
-    "description": "Step-by-step setup for OpenAI (funds required) and Gemini (credit card required) API keys and model selection for MT academy.",
+    "description": "Overview of MT academy’s managed OpenAI and Gemini access—no setup required.",
     "keywords": [
       "mock trial",
       "mock trial practice",
@@ -47,7 +47,7 @@
   </script>
 </head>
 <body>
-  <h1>API Keys / Engine</h1>
-  <p>OpenAI keys need funds deposited and Gemini keys require a linked credit card. Manage your keys on the <a href="./#keys">main MT academy page</a>.</p>
+  <h1>AI Access</h1>
+  <p>MT academy now handles the OpenAI and Gemini connections on our secure backend. Visit the <a href="./#keys">main MT academy page</a> to read about the proxy and switch between MT academy AI and the built-in scorer.</p>
 </body>
 </html>

--- a/howto.html
+++ b/howto.html
@@ -12,7 +12,7 @@
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=./#howto">
   <title>How to Use MT academy</title>
-  <meta name="description" content="Step-by-step guide for Objections, Video Coach, Writing, Rules, Rules Quiz, and setting up OpenAI (funds required) and Gemini (credit card required) API keys.">
+  <meta name="description" content="Step-by-step guide for Objections, Video Coach, Writing, Rules, and Rules Quiz with managed MT academy AI access—no setup required.">
   <meta name="keywords" content="mock trial, mock trial practice, mock trial resources, mock trial quizzes, high school mock trial, mock trial coaching, mock trial competition, MT academy">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://mocktrialacademy.com/howto.html">
@@ -21,7 +21,7 @@
   <link rel="shortcut icon" href="/favicon.svg" type="image/svg+xml">
   <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
   <meta property="og:title" content="How to Use MT academy">
-  <meta property="og:description" content="Step-by-step guide for Objections, Video Coach, Writing, Rules, Rules Quiz, and setting up OpenAI (funds required) and Gemini (credit card required) API keys.">
+  <meta property="og:description" content="Step-by-step guide for Objections, Video Coach, Writing, Rules, and Rules Quiz with managed MT academy AI access—no setup required.">
   <meta property="og:url" content="https://mocktrialacademy.com/howto.html">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="MT academy">
@@ -32,7 +32,7 @@
     "@type": "WebPage",
     "name": "How to Use MT academy",
     "url": "https://mocktrialacademy.com/howto.html",
-    "description": "Step-by-step guide for Objections, Video Coach, Writing, Rules, Rules Quiz, and setting up OpenAI (funds required) and Gemini (credit card required) API keys.",
+    "description": "Step-by-step guide for Objections, Video Coach, Writing, Rules, and Rules Quiz with managed MT academy AI access—no setup required.",
     "keywords": [
       "mock trial",
       "mock trial practice",
@@ -48,7 +48,7 @@
 </head>
 <body>
   <h1>How to Use</h1>
-  <p>Quick tips for MT academy's practice tools and API key setup. OpenAI keys need funds on the account, and Gemini keys must be linked to a credit card.</p>
+  <p>Quick tips for MT academy's practice tools. MT academy now supplies the AI access, so everything works without extra setup.</p>
   <p>See the full instructions on the <a href="./#howto">main page</a>.</p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -137,7 +137,6 @@ a.inline{color:var(--accent);text-decoration:underline}
     <a class="tab" href="#writing">Writing</a>
     <a class="tab" href="#rules" id="rulesTab">AZ Rules</a>
     <a class="tab" href="#quiz">Rules Quiz</a>
-    <a class="tab" href="#keys">API Keys</a>
     <a class="tab" href="#howto">How To Use</a>
     <a class="tab" href="#contact">Contact</a>
   </nav>
@@ -146,21 +145,12 @@ a.inline{color:var(--accent);text-decoration:underline}
   <div id="videoGate" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="videoGateTitle">
     <div class="modal">
       <h2 id="videoGateTitle">Choose how to score your performance</h2>
-      <div class="note">Use your own ChatGPT (OpenAI) account for rubric-based scoring or continue with the built-in scorer.</div>
+      <div class="note">MT academy now routes AI requests through a secure proxy. Pick whether to use our managed models or stay with the built-in heuristic scorer.</div>
       <div class="row">
         <div class="choice">
-          <h3>Option A — Use my ChatGPT account (recommended)</h3>
-          <ol class="small" style="margin-top:6px">
-            <li>Visit <strong>platform.openai.com</strong> and sign in.</li>
-            <li>Open <strong>Billing</strong> → <strong>Add payment method</strong> and deposit funds.</li>
-            <li>Go to <strong>API keys</strong> → <strong>Create new secret key</strong>.</li>
-            <li>Paste the key below. It is stored only in your browser (LocalStorage).</li>
-            <li>Select a model. “gpt-4o” is recommended.</li>
-          </ol>
-          <div class="ok" style="margin:8px 0">We never ask for your password. API key stays on this device.</div>
-          <label class="small">OpenAI API Key
-            <input id="openaiKey" class="input" type="password" placeholder="sk-...">
-          </label>
+          <h3>Option A — MT academy AI (recommended)</h3>
+          <p class="small">Uses managed OpenAI access through MT academy&rsquo;s backend. No personal setup required.</p>
+          <div class="ok" style="margin:8px 0">Private credentials stay on the server and nothing is stored locally.</div>
           <div class="row" style="margin-top:8px">
             <label class="small" style="flex:1">Model
               <select id="openaiModel" class="input">
@@ -172,8 +162,7 @@ a.inline{color:var(--accent);text-decoration:underline}
             </label>
           </div>
           <div class="row" style="margin-top:8px">
-            <button id="btnUseChatGPT" class="btn primary">Use ChatGPT Scoring</button>
-            <button id="btnForgetKey" class="btn secondary" title="Delete saved key">Remove saved key</button>
+            <button id="btnUseAcademy" class="btn primary">Use MT academy AI</button>
           </div>
         </div>
         <div class="choice">
@@ -184,15 +173,7 @@ a.inline{color:var(--accent);text-decoration:underline}
         </div>
         <div class="choice">
           <h3>Movement Scoring</h3>
-          <ol class="small" style="margin-top:6px">
-            <li>Visit <strong>ai.google.dev</strong> and sign in.</li>
-            <li>Create or select a project, then link a billing account with a credit card.</li>
-            <li>Go to <strong>API keys</strong> → <strong>Create API key</strong>.</li>
-            <li>Paste the key below. Stored only in your browser.</li>
-          </ol>
-          <label class="small">Gemini API Key
-            <input id="geminiKey" class="input" type="password" placeholder="AIza...">
-          </label>
+          <p class="small">Gemini gesture analysis also runs through the secure proxy. Choose your preferred model.</p>
           <label class="small" style="margin-top:8px">Model
             <select id="geminiModel" class="input">
               <option value="gemini-1.5-flash">gemini-1.5-flash (fast)</option>
@@ -200,8 +181,7 @@ a.inline{color:var(--accent);text-decoration:underline}
             </select>
           </label>
           <div class="row" style="margin-top:8px">
-            <button id="btnSaveGeminiKey" class="btn primary">Save Gemini Key</button>
-            <button id="btnForgetGeminiKey" class="btn secondary" title="Delete saved key">Remove</button>
+            <button id="btnSaveGeminiModel" class="btn primary">Save Movement Model</button>
           </div>
         </div>
       </div>
@@ -243,7 +223,7 @@ a.inline{color:var(--accent);text-decoration:underline}
         </select>
       </label>
       <button id="btnGPTNew" class="btn primary">GPT Prompt</button>
-      <button id="btnObjChangeEngine" class="btn secondary" title="Add or change API key">API Key</button>
+      <button id="btnObjChangeEngine" class="btn secondary" title="Choose MT academy or built-in engine">Choose AI Engine</button>
     </div>
     <div class="small" style="margin-top:8px">Press <strong>ChatGPT Argue</strong> to show argument actions.</div>
     <button id="btnGPTArgue" class="btn primary" style="width:100%;margin-top:4px">ChatGPT Argue</button>
@@ -281,7 +261,7 @@ a.inline{color:var(--accent);text-decoration:underline}
       <button id="btnScoreVideo" class="btn secondary">Re-score</button>
       <button id="btnShowVoice" class="btn secondary">Show Voice</button>
       <button id="btnAnalyzeMovement" class="btn secondary">Movement (Gemini)</button>
-      <button id="btnChangeEngine" class="btn secondary" title="Switch scoring engine or update API key">API Key / Engine</button>
+      <button id="btnChangeEngine" class="btn secondary" title="Choose MT academy or built-in engine">Choose AI Engine</button>
       <button id="btnTestChatGPT" class="btn secondary" title="Send a tiny test to ChatGPT">Test ChatGPT</button>
     </div>
     <div id="videoFeedback" class="small"></div>
@@ -305,7 +285,7 @@ a.inline{color:var(--accent);text-decoration:underline}
     <textarea id="gptWriteGoal" placeholder="Describe what you're trying to write or improve"></textarea>
     <div class="controls">
       <button id="btnGPTWrite" class="btn secondary">Ask ChatGPT to Draft</button>
-      <button id="btnWriteChangeEngine" class="btn secondary" title="Add or change API key">API Key / Engine</button>
+      <button id="btnWriteChangeEngine" class="btn secondary" title="Choose MT academy or built-in engine">Choose AI Engine</button>
     </div>
     <textarea id="gptWriteOutput" placeholder="ChatGPT output will appear here"></textarea>
     <div id="writeExemplar" class="small" style="margin-top:8px"></div>
@@ -338,60 +318,16 @@ a.inline{color:var(--accent);text-decoration:underline}
     <div id="quizBody" style="margin-top:8px"></div>
     <div id="quizExplain" class="small" style="margin-top:8px"></div>
   </section>
-  <!-- API Keys -->
+  <!-- Engine Info -->
   <section id="keys" class="card">
-    <h2>API Keys / Engine</h2>
-    <p class="small">Use your own API accounts for AI features. Keys are stored only in this browser.</p>
-    <div class="row">
-      <div class="choice">
-        <h3>ChatGPT Scoring</h3>
-        <ol class="small" style="margin-top:6px">
-          <li>Visit <strong>platform.openai.com</strong> and sign in.</li>
-          <li>Open <strong>Billing</strong> → <strong>Add payment method</strong> and deposit funds.</li>
-          <li>Go to <strong>API keys</strong> → <strong>Create new secret key</strong>.</li>
-          <li>Paste the key below and choose a model.</li>
-        </ol>
-        <label class="small">OpenAI API Key
-          <input id="keyPageOpenAI" class="input" type="password" placeholder="sk-...">
-        </label>
-        <div class="row" style="margin-top:8px">
-          <label class="small" style="flex:1">Model
-            <select id="keyPageOpenAIModel" class="input">
-              <option value="gpt-4o">gpt-4o</option>
-            </select>
-          </label>
-          <label class="small" style="flex:1">Max tokens
-            <input id="keyPageOpenAIMaxTokens" class="input" type="number" value="600" min="200" max="2000">
-          </label>
-        </div>
-        <div class="row" style="margin-top:8px">
-          <button id="saveOpenAI" class="btn primary">Save ChatGPT Key</button>
-          <button id="removeOpenAI" class="btn secondary">Remove</button>
-        </div>
-      </div>
-      <div class="choice">
-        <h3>Movement Scoring</h3>
-        <ol class="small" style="margin-top:6px">
-          <li>Visit <strong>ai.google.dev</strong> and sign in.</li>
-          <li>Create or select a project, then link a billing account with a credit card.</li>
-          <li>Go to <strong>API keys</strong> → <strong>Create API key</strong>.</li>
-          <li>Paste the key below and choose a model.</li>
-        </ol>
-        <label class="small">Gemini API Key
-          <input id="keyPageGemini" class="input" type="password" placeholder="AIza...">
-        </label>
-        <label class="small" style="margin-top:8px">Model
-          <select id="keyPageGeminiModel" class="input">
-            <option value="gemini-1.5-flash">gemini-1.5-flash (fast)</option>
-            <option value="gemini-1.5-pro">gemini-1.5-pro (accurate)</option>
-          </select>
-        </label>
-        <div class="row" style="margin-top:8px">
-          <button id="saveGemini" class="btn primary">Save Gemini Key</button>
-          <button id="removeGemini" class="btn secondary">Remove</button>
-        </div>
-      </div>
-    </div>
+    <h2>MT academy AI Access</h2>
+    <p class="small">All AI-powered features run through MT academy&rsquo;s secure proxy, so everything works automatically.</p>
+    <ul class="small">
+      <li>Requests travel through our backend before reaching OpenAI or Gemini.</li>
+      <li>The browser only ever sees the responses, and nothing sensitive is stored on the device.</li>
+      <li>You can still switch to the offline heuristic engine at any time from the scoring modal.</li>
+    </ul>
+    <button class="btn secondary" onclick="openVideoGate()">Choose AI engine</button>
   </section>
   <!-- How To -->
   <section id="howto" class="card">
@@ -415,8 +351,8 @@ a.inline{color:var(--accent);text-decoration:underline}
           <li>Select the speech type and click <em>Start Recording</em>.</li>
           <li>Use <em>Stop</em> when done, then <em>Play</em> or <em>Download</em> to review.</li>
           <li><em>Re-score</em> analyzes delivery; <em>Show Voice</em> displays the transcript.</li>
-          <li><em>Movement (Gemini)</em> checks gestures; <em>API Key / Engine</em> adds keys.</li>
-          <li><em>Test ChatGPT</em> confirms your key works.</li>
+          <li><em>Movement</em> checks gestures; <em>Choose AI Engine</em> lets you switch between MT academy AI and the built-in scorer.</li>
+          <li><em>Test ChatGPT</em> makes sure the MT academy AI connection is ready.</li>
         </ul>
       </li>
       <li>
@@ -444,7 +380,7 @@ a.inline{color:var(--accent);text-decoration:underline}
         </ul>
       </li>
     </ul>
-    <p class="small">To use ChatGPT or Gemini features, create your own API keys. OpenAI keys require prepaid funds, and Gemini keys need a linked credit card. See the API Keys page for step-by-step setup.</p>
+    <p class="small">MT academy handles the AI connection behind the scenes. Use <em>Choose AI Engine</em> anywhere in the app if you want to switch back to the built-in heuristic scorer.</p>
   </section>
   <!-- Contact -->
   <section id="contact" class="card">
@@ -974,7 +910,7 @@ var CURRENT_STATE='AZ';
 function $(id){return document.getElementById(id);}
 function Q(s){return Array.from(document.querySelectorAll(s));}
 // Predeclare EngineState to avoid reference errors in non-browser environments.
-var EngineState = { mode: 'builtin', openaiKey: '', openaiModel: 'gpt-4o', openaiMaxTokens: 600, geminiKey: '', geminiModel: 'gemini-1.5-flash' };
+var EngineState = { mode: 'academy', openaiModel: 'gpt-4o', openaiMaxTokens: 600, geminiModel: 'gemini-1.5-flash' };
 // Ensure the script only runs in a browser environment.
 if (typeof window !== 'undefined' && typeof document !== 'undefined') {
 /* Debug + provenance */
@@ -1088,35 +1024,44 @@ function makeRubricMap(stateName, abbr){
 
 /* Global engine state */
 EngineState = {
-  get mode(){ return load('mtpl.engineMode','builtin') },           // 'builtin' | 'chatgpt'
-  set mode(v){ save('mtpl.engineMode', v); renderModeBadge() },
-  get openaiKey(){ return load('mtpl.openaiKey','') },
-  set openaiKey(v){ save('mtpl.openaiKey', v||'') },
+  get mode(){
+    const raw = load('mtpl.engineMode','academy');
+    return raw === 'chatgpt' ? 'academy' : raw;
+  },           // 'builtin' | 'academy'
+  set mode(v){
+    const normalized = v === 'builtin' ? 'builtin' : 'academy';
+    save('mtpl.engineMode', normalized);
+    renderModeBadge();
+  },
   get openaiModel(){ return load('mtpl.openaiModel','gpt-4o') },
   set openaiModel(v){ save('mtpl.openaiModel', v||'gpt-4o') },
   get openaiMaxTokens(){ return load('mtpl.openaiMaxTokens',600) },
   set openaiMaxTokens(v){ save('mtpl.openaiMaxTokens', Number(v)||600) },
-  get geminiKey(){ return load('mtpl.geminiKey','') },
-  set geminiKey(v){ save('mtpl.geminiKey', v||'') },
   get geminiModel(){ return load('mtpl.geminiModel','gemini-1.5-flash') },
   set geminiModel(v){ save('mtpl.geminiModel', v||'gemini-1.5-flash') }
 };
 
-if (EngineState.openaiKey && EngineState.mode !== 'chatgpt') {
-  EngineState.mode = 'chatgpt';
-}
+try {
+  localStorage.removeItem('mtpl.openaiKey');
+  localStorage.removeItem('mtpl.geminiKey');
+} catch (_) {}
+
 renderModeBadge();
 
 function renderModeBadge(){
   const b=$('modeBadge'), banner=$('videoModeBanner');
   if(!b) return;
-  if(EngineState.mode==='chatgpt' && EngineState.openaiKey){
-    b.textContent='Mode: ChatGPT (OpenAI API)';
-    if(banner) banner.innerHTML = 'Scoring via <strong>ChatGPT (OpenAI API)</strong>.';
+  if(EngineState.mode==='academy'){
+    b.textContent='Mode: MT academy AI (OpenAI)';
+    if(banner) banner.innerHTML = 'Scoring via <strong>MT academy AI</strong>.';
   } else {
     b.textContent='Mode: Built-in (less accurate)';
     if(banner) banner.innerHTML = 'Scoring via <strong>built-in heuristic engine</strong>.';
   }
+}
+
+function isAcademyMode(){
+  return EngineState.mode === 'academy';
 }
 
 /* Navigation menu links */
@@ -1132,97 +1077,40 @@ document.addEventListener('DOMContentLoaded',()=>{
 });
 
 /* Gateway wiring */
-function openVideoGate(){ $('videoGate').style.display='flex'; $('openaiKey').value = EngineState.openaiKey||''; $('openaiModel').value=EngineState.openaiModel; $('openaiMaxTokens').value=EngineState.openaiMaxTokens; $('geminiKey').value=EngineState.geminiKey||''; $('geminiModel').value=EngineState.geminiModel; }
+function openVideoGate(){
+  $('videoGate').style.display='flex';
+  const openaiModel=$('openaiModel');
+  const openaiMax=$('openaiMaxTokens');
+  const gemModel=$('geminiModel');
+  if(openaiModel) openaiModel.value=EngineState.openaiModel;
+  if(openaiMax) openaiMax.value=EngineState.openaiMaxTokens;
+  if(gemModel) gemModel.value=EngineState.geminiModel;
+}
 function closeVideoGate(){ $('videoGate').style.display='none' }
-function maybeShowVideoGate(){ const seen=load('mtpl.videoGateSeen',false); const hasChoice=!!EngineState.mode; if(!seen||!hasChoice){ openVideoGate(); save('mtpl.videoGateSeen',true); } }
+function maybeShowVideoGate(){ const seen=load('mtpl.videoGateSeen',false); if(!seen){ openVideoGate(); save('mtpl.videoGateSeen',true); } }
 function attachVideoGateHandlers(){
   $('btnCloseGate').addEventListener('click', closeVideoGate);
   $('btnUseBuiltin').addEventListener('click', ()=>{
     EngineState.mode='builtin'; closeVideoGate(); renderModeBadge();
     $('videoStatus').textContent='Using built-in scoring (less accurate). You can switch engines anytime.';
   });
-  $('btnUseChatGPT').addEventListener('click', ()=>{
-    const key = $('openaiKey').value.trim();
-    const model = $('openaiModel').value;
-    const maxt = Number($('openaiMaxTokens').value) || 600;
-    // Accept sk- and sk-proj- and other future variants that start with sk-
-    const isValidKey = /^sk-[A-Za-z0-9_-]{10,}$/.test(key);
-    if (!isValidKey) {
-      alert('Paste a valid OpenAI API key (starts with \u201csk-\u201d).');
-      return;
-    }
-    EngineState.openaiKey=key; EngineState.openaiModel=model; EngineState.openaiMaxTokens=maxt; EngineState.mode='chatgpt';
+  $('btnUseAcademy').addEventListener('click', ()=>{
+    const model=$('openaiModel').value;
+    const maxt=Number($('openaiMaxTokens').value)||600;
+    EngineState.openaiModel=model;
+    EngineState.openaiMaxTokens=maxt;
+    EngineState.mode='academy';
     closeVideoGate(); renderModeBadge();
-    $('videoStatus').textContent='ChatGPT scoring enabled. Paste or record a transcript, then click Re-score.';
+    $('videoStatus').textContent='MT academy AI enabled. Paste or record a transcript, then click Re-score.';
   });
-  $('btnForgetKey').addEventListener('click', ()=>{
-    EngineState.openaiKey=''; EngineState.mode='builtin'; renderModeBadge();
-    alert('Removed saved API key. Falling back to built-in scoring.');
-  });
-  $('btnSaveGeminiKey')?.addEventListener('click', ()=>{
-    const key=$('geminiKey').value.trim();
+  $('btnSaveGeminiModel')?.addEventListener('click', ()=>{
     const model=$('geminiModel').value;
-    if(!key){ alert('Paste a Gemini API key.'); return; }
-    EngineState.geminiKey=key; EngineState.geminiModel=model;
+    EngineState.geminiModel=model;
     closeVideoGate();
-    const s=$('videoStatus'); if(s) s.textContent='Gemini key saved. Use Movement for analysis.';
-  });
-  $('btnForgetGeminiKey')?.addEventListener('click', ()=>{
-    EngineState.geminiKey='';
-    const s=$('videoStatus'); if(s) s.textContent='Removed Gemini key.';
+    const s=$('videoStatus'); if(s) s.textContent=`Gemini movement model saved (${model}).`;
   });
 }
 document.addEventListener('DOMContentLoaded', attachVideoGateHandlers);
-
-function initKeyPage(){
-  const openaiInput = $('keyPageOpenAI');
-  const openaiModel = $('keyPageOpenAIModel');
-  const openaiMax = $('keyPageOpenAIMaxTokens');
-  const geminiInput = $('keyPageGemini');
-  const geminiModel = $('keyPageGeminiModel');
-  if(!openaiInput || !openaiModel || !openaiMax || !geminiInput || !geminiModel) return;
-  openaiInput.value = EngineState.openaiKey || '';
-  openaiModel.value = EngineState.openaiModel;
-  openaiMax.value = EngineState.openaiMaxTokens;
-  geminiInput.value = EngineState.geminiKey || '';
-  geminiModel.value = EngineState.geminiModel;
-  $('saveOpenAI').addEventListener('click', ()=>{
-    const key = openaiInput.value.trim();
-    if(!/^sk-[A-Za-z0-9_-]{10,}$/.test(key)){
-      alert('Paste a valid OpenAI key (starts with "sk-").');
-      return;
-    }
-    EngineState.openaiKey = key;
-    EngineState.openaiModel = openaiModel.value;
-    EngineState.openaiMaxTokens = Number(openaiMax.value) || 600;
-    EngineState.mode = 'chatgpt';
-    renderModeBadge();
-    alert('OpenAI key saved.');
-  });
-  $('removeOpenAI').addEventListener('click', ()=>{
-    EngineState.openaiKey = '';
-    EngineState.mode = 'builtin';
-    openaiInput.value = '';
-    renderModeBadge();
-    alert('OpenAI key removed.');
-  });
-  $('saveGemini').addEventListener('click', ()=>{
-    const key = geminiInput.value.trim();
-    if(!key){
-      alert('Paste a Gemini key.');
-      return;
-    }
-    EngineState.geminiKey = key;
-    EngineState.geminiModel = geminiModel.value;
-    alert('Gemini key saved.');
-  });
-  $('removeGemini').addEventListener('click', ()=>{
-    EngineState.geminiKey = '';
-    geminiInput.value = '';
-    alert('Gemini key removed.');
-  });
-}
-document.addEventListener('DOMContentLoaded', initKeyPage);
 
 /* Env warnings + error surface */
 function envWarn(){
@@ -1283,26 +1171,28 @@ function evaluateRubric(){ return {org:4,delivery:5,content:4,presence:6,words:0
 
   // Transcribe with OpenAI (tries multiple models, graceful fallback)
   root.transcribeFile = async function transcribeFile(file, filenameHint){
-    const key = (typeof EngineState!=="undefined") ? EngineState.openaiKey : "";
-    if(!key) return "";
+    if(!isAcademyMode()) return \"\";
 
-    const tryModels = ["whisper-1", "gpt-4o-transcribe"];
+    const tryModels = [\"whisper-1\", \"gpt-4o-transcribe\"];
     const mkForm = (f, name) => {
       const form = new FormData();
-      form.append("file", f, name || "audio.wav");
-      form.append("temperature", "0");
+      form.append(\"file\", f, name || \"audio.wav\");
+      form.append(\"temperature\", \"0\");
       return form;
     };
 
     for (const m of tryModels) {
       try {
-        const form = mkForm(file, filenameHint || "audio.wav");
-        form.append("model", m);
-        const resp = await fetch("https://api.openai.com/v1/audio/transcriptions", {
-          method: "POST",
-          headers: { "Authorization": `Bearer ${key}` },
+        const form = mkForm(file, filenameHint || \"audio.wav\");
+        form.append(\"model\", m);
+        const resp = await fetch(\"/api/openai/transcriptions\", {
+          method: \"POST\",
           body: form
         });
+        if(!resp.ok){
+          const errText = await resp.text();
+          throw new Error(errText || 'Transcription request failed');
+        }
         const data = await resp.json();
         if (data?.text) return data.text.trim();
         if (data?.error?.message) throw new Error(data.error.message);
@@ -1310,12 +1200,11 @@ function evaluateRubric(){ return {org:4,delivery:5,content:4,presence:6,words:0
         // try the next model
       }
     }
-    return "";
+    return \"\";
   };
 
   root.transcribeFileDetailed = async function transcribeFileDetailed(file, filenameHint){
-    const key = (typeof EngineState!=="undefined") ? EngineState.openaiKey : "";
-    if(!key) return { text:"", words:[] };
+    if(!isAcademyMode()) return { text:"", words:[] };
     const tryModels=["whisper-1","gpt-4o-transcribe"];
     const mkForm=(f,name)=>{
       const form=new FormData();
@@ -1329,11 +1218,14 @@ function evaluateRubric(){ return {org:4,delivery:5,content:4,presence:6,words:0
       try{
         const form=mkForm(file,filenameHint||"audio.wav");
         form.append("model",m);
-        const resp=await fetch("https://api.openai.com/v1/audio/transcriptions",{
+        const resp=await fetch("/api/openai/transcriptions",{
           method:"POST",
-          headers:{"Authorization":`Bearer ${key}`},
           body:form
         });
+        if(!resp.ok){
+          const errText = await resp.text();
+          throw new Error(errText || 'Transcription request failed');
+        }
         const data=await resp.json();
         if(data?.text){
           const words=[];
@@ -1359,43 +1251,17 @@ function evaluateRubric(){ return {org:4,delivery:5,content:4,presence:6,words:0
 </script>
 <script>
 // --- REPLACE callOpenAIChat with this hardened version ---
-async function callOpenAIChat({ messages, model, maxTokens = 600, json = false, signal }) {
-  if (!EngineState.openaiKey || !/^sk-[A-Za-z0-9_-]{10,}/.test(EngineState.openaiKey)) {
-    const err = new Error('Missing or malformed OpenAI API key.');
+async function callOpenAIChat({ messages, model, maxTokens = 600, json = false, signal, temperature = 0 }) {
+  if (!isAcademyMode()) {
+    const err = new Error('MT academy AI is disabled.');
     err.type = 'config';
     throw err;
   }
 
-  // 1) Quick ping to fail fast on invalid key/quota
-  async function ping() {
-    try {
-      const r = await fetch('https://api.openai.com/v1/models', {
-        method: 'GET',
-        headers: { Authorization: `Bearer ${EngineState.openaiKey}` },
-        cache: 'no-store',
-        keepalive: true,
-      });
-      if (!r.ok) {
-        const t = await r.text().catch(()=> '');
-        let msg = 'OpenAI auth/models check failed';
-        try { const j = JSON.parse(t); msg = j?.error?.message || msg; } catch {}
-        const e = new Error(msg);
-        e.status = r.status;
-        throw e;
-      }
-    } catch (e) {
-      // Don’t block if ping fails due to adblockers; only throw on clear auth errors
-      if (e?.status === 401 || e?.status === 429 || e?.status === 403) throw e;
-    }
-  }
-
-  // 2) Try the ping, but ignore network-only failures
-  try { await ping(); } catch (e) { /* surface later if main call fails */ }
-
   const baseBody = {
     model,
     messages,
-    temperature: 0,
+    temperature: Number.isFinite(temperature) ? temperature : 0,
     max_tokens: Math.max(50, Math.min(8192, Number(maxTokens) || 600)),
   };
 
@@ -1404,11 +1270,10 @@ async function callOpenAIChat({ messages, model, maxTokens = 600, json = false, 
       ? { ...baseBody, response_format: { type: 'json_object' } }
       : baseBody;
 
-    const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+    const resp = await fetch('/api/openai/chat', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${EngineState.openaiKey}`,
       },
       body: JSON.stringify(body),
       signal,
@@ -1416,7 +1281,6 @@ async function callOpenAIChat({ messages, model, maxTokens = 600, json = false, 
       keepalive: true,
     });
 
-    // Read text first to preserve error detail
     const rawText = await resp.text();
     let data = null;
     try { data = JSON.parse(rawText); } catch {}
@@ -1424,7 +1288,7 @@ async function callOpenAIChat({ messages, model, maxTokens = 600, json = false, 
     if (!resp.ok) {
       const e = new Error(
         data?.error?.message ||
-        `OpenAI HTTP ${resp.status}${rawText ? ` — ${rawText.slice(0, 200)}` : ''}`
+        `OpenAI proxy HTTP ${resp.status}${rawText ? ` — ${rawText.slice(0, 200)}` : ''}`
       );
       e.status = resp.status;
       e.code = data?.error?.code;
@@ -1439,14 +1303,12 @@ async function callOpenAIChat({ messages, model, maxTokens = 600, json = false, 
     return String(content || '');
   }
 
-  // 3) Try JSON first, gracefully fall back to text
   try {
     return await attempt(json);
   } catch (e) {
     const msg = String(e?.message || '').toLowerCase();
     const isSchemaish = msg.includes('response_format') || msg.includes('json');
     if (json && (e.status === 400 || isSchemaish)) {
-      // Retry in plain text mode
       return await attempt(false);
     }
     if (e.status === 429) e.code = e.code || 'rate_limit';
@@ -1646,8 +1508,8 @@ function newQ(){const p=pool();cur=p.length?p[Math.floor(Math.random()*(p.length
 function check(){if(!cur)return;const ok=norm($('objSelect').value)===norm(cur.ans);const r=$('objResult');r.hidden=false;r.classList.toggle('ok',ok);r.classList.toggle('bad',!ok);$('objRuling').textContent=ok?'Sustained.':'Overruled.';$('objRule').textContent=cur.rule;$('objWhy').textContent=cur.why;updStats(cat(cur.ans),ok)}
 function model(){if(!cur)return;const r=$('objResult');r.hidden=false;$('objRuling').textContent='Model Answer';$('objRule').textContent=cur.rule;$('objWhy').textContent=`${cur.why} (Correct: ${cur.ans})`}
  async function gptNew(){
-  if(!(EngineState.mode==='chatgpt' && EngineState.openaiKey)){
-   alert('ChatGPT mode not enabled or API key missing.');
+  if(!isAcademyMode()){
+   alert('MT academy AI mode is disabled. Use “Choose AI Engine” to enable it.');
    return;
   }
   const diff=$('objGPTDiff').value||'easy';
@@ -1664,13 +1526,7 @@ function model(){if(!cur)return;const r=$('objResult');r.hidden=false;$('objRuli
    ];
    const model=EngineState.openaiModel||'gpt-4o';
    const tokenParam=chatTokenParam(model,250);
-   const resp=await fetch('https://api.openai.com/v1/chat/completions',{
-    method:'POST',
-    headers:{'Content-Type':'application/json','Authorization':`Bearer ${EngineState.openaiKey}`},
-    body:JSON.stringify({model,messages,response_format:{type:'json_object'},...tokenParam})
-   });
-   const data=await resp.json();
-   const raw=data?.choices?.[0]?.message?.content||'';
+   const raw=await callOpenAIChat({ messages, model, maxTokens: tokenParam.max_tokens, json: true });
    const obj=extractFirstJson(raw);
    if(obj&&obj.fact&&obj.q&&obj.ans){
     cur=obj;
@@ -1691,8 +1547,8 @@ function model(){if(!cur)return;const r=$('objResult');r.hidden=false;$('objRuli
  }
  async function gptArgue(){
   if(!cur){alert('Get a prompt first.');return;}
-  if(!(EngineState.mode==='chatgpt' && EngineState.openaiKey)){
-   alert('ChatGPT mode not enabled or API key missing.');
+  if(!isAcademyMode()){
+   alert('MT academy AI mode is disabled. Use “Choose AI Engine” to enable it.');
    return;
   }
  const role = $('objGPTRole').value || 'chatgpt';
@@ -1756,15 +1612,9 @@ Task:
    try{
     const model=EngineState.openaiModel||'gpt-4o';
     const tokenParam=chatTokenParam(model,150);
-    const resp=await fetch('https://api.openai.com/v1/chat/completions',{
-     method:'POST',
-     headers:{'Content-Type':'application/json','Authorization':`Bearer ${EngineState.openaiKey}`},
-     body:JSON.stringify({model,messages:gptChat,temperature:0.7,...tokenParam})
-    });
-   const data=await resp.json();
-   const text=data?.choices?.[0]?.message?.content?.trim()||'';
-   gptChat.push({role:'assistant',content:text});
-   appendChat('chatgpt',text);
+    const text=(await callOpenAIChat({ messages: gptChat, model, maxTokens: tokenParam.max_tokens, temperature: 0.7 })).trim();
+    gptChat.push({role:'assistant',content:text});
+    appendChat('chatgpt',text);
   }catch(e){
    console.error('[GPT Argue]',e);
    const raw = e?.raw ? (typeof e.raw === 'string' ? e.raw.slice(0,200) : JSON.stringify(e.raw).slice(0,200)) : '';
@@ -1772,7 +1622,7 @@ Task:
   }
   }
   async function gptSend(){
-   if(!(EngineState.mode==='chatgpt' && EngineState.openaiKey)){alert('ChatGPT mode not enabled or API key missing.');return;}
+   if(!isAcademyMode()){alert('MT academy AI mode is disabled. Use “Choose AI Engine” to enable it.');return;}
    const inp=$('objGPTInput');const txt=inp.value.trim();if(!txt)return;inp.value='';
    updateGPTSend();
   gptChat.push({role:'user',content:txt});
@@ -1780,13 +1630,7 @@ Task:
   try{
    const model=EngineState.openaiModel||'gpt-4o';
    const tokenParam=chatTokenParam(model,150);
-   const resp=await fetch('https://api.openai.com/v1/chat/completions',{
-     method:'POST',
-     headers:{'Content-Type':'application/json','Authorization':`Bearer ${EngineState.openaiKey}`},
-     body:JSON.stringify({model,messages:gptChat,temperature:0.7,...tokenParam})
-    });
-   const data=await resp.json();
-   const reply=data?.choices?.[0]?.message?.content?.trim()||'';
+   const reply=(await callOpenAIChat({ messages: gptChat, model, maxTokens: tokenParam.max_tokens, temperature: 0.7 })).trim();
    gptChat.push({role:'assistant',content:reply});
    appendChat('chatgpt',reply);
   }catch(e){
@@ -1796,12 +1640,12 @@ Task:
   }
   }
 function gptRecord(){
-  if(!(EngineState.mode==='chatgpt' && EngineState.openaiKey)){alert('ChatGPT mode not enabled or API key missing.');return;}
+  if(!isAcademyMode()){alert('MT academy AI mode is disabled. Use “Choose AI Engine” to enable it.');return;}
   $('objGPTInput').value='';
   updateGPTSend();
   const SR=window.SpeechRecognition||window.webkitSpeechRecognition;
-  // Prefer OpenAI transcription when an API key is available
-  if(EngineState.openaiKey && navigator.mediaDevices&&navigator.mediaDevices.getUserMedia){
+  // Prefer MT academy transcription when the managed AI is enabled
+  if(isAcademyMode() && navigator.mediaDevices&&navigator.mediaDevices.getUserMedia){
    const getMicStream = async () => {
      try {
        return await navigator.mediaDevices.getUserMedia({audio:{channelCount:1,noiseSuppression:true,echoCancellation:true}});
@@ -1840,7 +1684,7 @@ function gptRecord(){
      }
    }).catch(err=>alert('Mic error: '+err.message));
   } else if(SR){
-   // Fallback to browser speech recognition when no API key is available
+   // Fallback to browser speech recognition when MT academy AI is disabled
    gptRecog=new SR();
    let txt='';
    gptRecog.lang='en-US';
@@ -1880,8 +1724,8 @@ function gptStopRecord(){
   }
 }
   async function gptRule(){
-    if(!(EngineState.mode==='chatgpt' && EngineState.openaiKey)){
-      alert('ChatGPT mode not enabled or API key missing.');
+    if(!isAcademyMode()){
+      alert('MT academy AI mode is disabled. Use “Choose AI Engine” to enable it.');
       return;
     }
 
@@ -1936,18 +1780,7 @@ Scoring rule:
     try{
       const model = EngineState.openaiModel || 'gpt-4o';
       const tokenParam = chatTokenParam(model,400);
-      const resp = await fetch('https://api.openai.com/v1/chat/completions',{
-        method:'POST',
-        headers:{'Content-Type':'application/json','Authorization':`Bearer ${EngineState.openaiKey}`},
-        body: JSON.stringify({
-          model,
-          messages:[{role:'user', content: prompt}],
-          temperature: 0.7,
-          ...tokenParam
-        })
-      });
-      const data = await resp.json();
-      const text = data?.choices?.[0]?.message?.content?.trim() || '';
+      const text = (await callOpenAIChat({ messages:[{role:'user', content: prompt}], model, maxTokens: tokenParam.max_tokens, temperature: 0.7 } )).trim();
 
       try{
         const parsed = ChatGPTScoring.parseScoreResponse(text); // unchanged parser
@@ -2394,7 +2227,7 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
       }
 
       let words=[], transcript="";
-      if(typeof EngineState!=="undefined" && EngineState.openaiKey){
+      if(typeof EngineState!=="undefined" && isAcademyMode()){
         try{
           const wav=await blobToWav(blob);
           const t=await transcribeFileDetailed(wav,'audio.wav');
@@ -2556,7 +2389,7 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
 
   // Hardened: timeout + retry + JSON-safe parsing + logs
   async function scoreViaChatGPT(type, transcript){
-    if(!EngineState.openaiKey) throw new Error("no_key");
+    if(!isAcademyMode()) throw new Error("no_key");
     const model = EngineState.openaiModel || "gpt-4o";
     const maxTokens = Math.max(200, Math.min(2000, Number(EngineState.openaiMaxTokens)||600));
 
@@ -2684,7 +2517,7 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
       return;
     }
 
-    if(EngineState.mode==='chatgpt' && EngineState.openaiKey){
+    if(isAcademyMode()){
       $('videoStatus').textContent='Scoring via ChatGPT\u2026';
       scoreViaChatGPT(type, transcript).then(parsed=>{
   // Use the LLM output AS-IS (no local blending, no WPM/length nudges)
@@ -2732,14 +2565,14 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
   showProvenance('LLM-only rubric scoring (no local blend).');
 }).catch(err => {
   // Surface precise error info
-  let msg = 'ChatGPT scoring unavailable \u2014 using built-in for this run.';
-  if (err?.status === 401) msg = 'OpenAI API key invalid/expired (401). Update your key in \u201cAPI Key / Engine\u201d.';
-  else if (err?.status === 429 || err?.code === 'rate_limit') msg = 'Rate limit on your OpenAI account (429). Try again or switch model.';
-  else if (err?.status === 403) msg = 'OpenAI request forbidden (403). Check org/project access for this key.';
-  else if (err?.code === 'insufficient_quota') msg = 'OpenAI quota exhausted. Add billing or change organization.';
+  let msg = 'ChatGPT scoring unavailable — using built-in for this run.';
+  if (err?.status === 401) msg = 'MT academy AI request returned 401. Please contact the site administrator.';
+  else if (err?.status === 429 || err?.code === 'rate_limit') msg = 'MT academy AI hit a rate limit (429). Try again shortly.';
+  else if (err?.status === 403) msg = 'MT academy AI request forbidden (403). Please notify the site administrator.';
+  else if (err?.code === 'insufficient_quota') msg = 'Managed OpenAI quota is exhausted. Try again later.';
   else if ((err?.message || '').toLowerCase().includes('network'))
-    msg = 'Network error reaching OpenAI. Check ad blockers / CORS / HTTPS.';
-  else if (err?.message) msg = `OpenAI error: ${err.message}`;
+    msg = 'Network error reaching the MT academy AI proxy. Check ad blockers / CORS / HTTPS.';
+  else if (err?.message) msg = `MT academy AI error: ${err.message}`;
 
   const detail = err?.raw ? (typeof err.raw === 'string' ? err.raw.slice(0, 300) : JSON.stringify(err.raw).slice(0, 300)) : '';
   $('videoStatus').innerHTML = `<strong>${escHTML(msg)}</strong>${detail ? `<div class="small">${escHTML(detail)}</div>` : ''}`;
@@ -2747,7 +2580,7 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
 
   // Do NOT flip engine mode; just fall back this run
   scoreWithBuiltin(type, raw, audio);
-  showProvenance('Built-in score used (OpenAI error).', true);
+  showProvenance('Built-in score used (MT academy AI error).', true);
 
   const badge = $('modeBadge');
   if (badge && /ChatGPT/i.test(badge.textContent)) {
@@ -2761,8 +2594,8 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
   }
 
   async function testChatGPT(){
-    if (!(EngineState.mode==='chatgpt' && EngineState.openaiKey)) {
-      alert('ChatGPT mode not enabled or API key missing. Click \u201cAPI Key / Engine\u201d.');
+    if (!isAcademyMode()) {
+      alert('MT academy AI mode is disabled. Click \u201cAPI Key / Engine\u201d.');
       return;
     }
     showProvenance('Testing ChatGPT\u2026');
@@ -2786,10 +2619,6 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
   }
 
   async function analyzeMovement(){
-    if(!EngineState.geminiKey){
-      alert('Add a Gemini API key in “API Key / Engine”.');
-      return;
-    }
     if(!lastVideoBlob || !lastVideoBlob.type.startsWith('video/')){
       alert('Record a video first.');
       return;
@@ -2803,14 +2632,13 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
     try{
       const b64 = await blobToBase64(lastVideoBlob);
       const model = EngineState.geminiModel || 'gemini-1.5-flash';
-      const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${EngineState.geminiKey}`;
       const prompt = 'You are a mock trial performance coach. Watch the video and read the transcript. Give a concise bullet list of movement and gesture improvements. Each item must cite an approximate timestamp (mm:ss) or transcript sentence and explain how, where, and when to move or gesture differently.';
       const mime = (lastVideoBlob.type||'video/mp4').split(';')[0];
-      const body = {contents:[{role:'user',parts:[{text:prompt},{inlineData:{mimeType:mime,data:b64}},{text:'Transcript:\n'+transcript}]}],generationConfig:{maxOutputTokens:512}};
-      const resp=await fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+      const payload = { model, prompt, transcript, video: { mimeType: mime, data: b64 } };
+      const resp=await fetch('/api/gemini/movement',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
       if(!resp.ok){
         const errTxt = await resp.text();
-        let msg = 'Gemini API error';
+        let msg = 'Gemini proxy error';
         try{ msg = JSON.parse(errTxt).error?.message || msg; }catch(_){ if(errTxt) msg = errTxt; }
         throw new Error(msg);
       }
@@ -2825,8 +2653,8 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
   }
 
   async function gptWrite(){
-    if(!(EngineState.mode==='chatgpt' && EngineState.openaiKey)){
-      alert('ChatGPT mode not enabled or API key missing. Click \u201cAPI Key / Engine\u201d.');
+    if(!isAcademyMode()){
+      alert('MT academy AI mode is disabled. Click \u201cAPI Key / Engine\u201d.');
       return;
     }
     const type=$('writeType').value;
@@ -2842,13 +2670,7 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
     try{
       const model=EngineState.openaiModel||'gpt-4o';
       const tokenParam=chatTokenParam(model,maxTokens);
-      const resp=await fetch('https://api.openai.com/v1/chat/completions',{
-        method:'POST',
-        headers:{'Content-Type':'application/json','Authorization':`Bearer ${EngineState.openaiKey}`},
-        body:JSON.stringify({model,messages,temperature:0.7,...tokenParam})
-      });
-      const data=await resp.json();
-      const text=data?.choices?.[0]?.message?.content?.trim()||'';
+      const text=(await callOpenAIChat({ messages, model, maxTokens: tokenParam.max_tokens, temperature: 0.7 })).trim();
       out.value=text;
     }catch(e){
       console.error('[GPT Write]',e);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1096 @@
+{
+  "name": "mt-academy",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mt-academy",
+      "version": "1.0.0",
+      "dependencies": {
+        "axios": "^1.6.8",
+        "dotenv": "^16.4.5",
+        "express": "^4.19.2",
+        "form-data": "^4.0.0",
+        "multer": "^2.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "mkdirp": "^0.5.6",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.18",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mt-academy",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node server/index.js",
+    "save-keys": "node scripts/save-keys.js",
+    "setup": "node scripts/setup.js"
+  },
+  "dependencies": {
+    "axios": "^1.6.8",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "form-data": "^4.0.0",
+    "multer": "^2.0.0"
+  }
+}

--- a/scripts/save-keys.js
+++ b/scripts/save-keys.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+const envPath = path.resolve(process.cwd(), '.env');
+const examplePath = path.resolve(process.cwd(), '.env.example');
+
+if (!fs.existsSync(envPath)) {
+  if (fs.existsSync(examplePath)) {
+    fs.copyFileSync(examplePath, envPath);
+    console.log("I couldn't find .env, so I copied .env.example for you.\n");
+  } else {
+    const blankTemplate = ['OPENAI_API_KEY=', 'GEMINI_API_KEY='].join('\n');
+    fs.writeFileSync(envPath, `${blankTemplate}\n`);
+    console.log("I made a brand-new .env file for you.\n");
+  }
+}
+
+const envText = fs.readFileSync(envPath, 'utf8');
+const lines = envText.split(/\r?\n/);
+const keyNames = ['OPENAI_API_KEY', 'GEMINI_API_KEY'];
+const placeholders = {
+  OPENAI_API_KEY: 'sk-your-openai-key-here',
+  GEMINI_API_KEY: 'your-gemini-key-here',
+};
+const currentValues = {};
+
+for (const key of keyNames) {
+  const line = lines.find((entry) => entry.startsWith(`${key}=`));
+  if (line) {
+    const rawValue = line.slice(key.length + 1);
+    currentValues[key] = rawValue === placeholders[key] ? '' : rawValue;
+  }
+}
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+function askForKey(index, answers) {
+  if (index >= keyNames.length) {
+    rl.close();
+    saveKeys({ ...currentValues, ...answers });
+    return;
+  }
+
+  const key = keyNames[index];
+  const friendlyName = key === 'OPENAI_API_KEY' ? 'OpenAI' : 'Gemini';
+  const prompt = `Paste your ${friendlyName} key (or press Enter to skip): `;
+
+  rl.question(prompt, (value) => {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      answers[key] = trimmed;
+    }
+    askForKey(index + 1, answers);
+  });
+}
+
+function saveKeys(values) {
+  const updatedLines = lines.map((line) => {
+    for (const key of keyNames) {
+      if (line.startsWith(`${key}=`)) {
+        return `${key}=${values[key] ?? ''}`;
+      }
+    }
+    return line;
+  });
+
+  for (const key of keyNames) {
+    if (!updatedLines.some((line) => line.startsWith(`${key}=`))) {
+      updatedLines.push(`${key}=${values[key] ?? ''}`);
+    }
+  }
+
+  const output = updatedLines.join('\n').replace(/\n+$/, '\n');
+  fs.writeFileSync(envPath, output);
+  console.log('\nAll set! Your keys are saved safely inside .env.');
+}
+
+console.log('Hi friend! Let me tuck your keys into .env for you.');
+askForKey(0, {});

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const projectRoot = process.cwd();
+
+function runStep(stepName, command, args) {
+  console.log(`\n➡️  ${stepName}`);
+  const result = spawnSync(command, args, {
+    cwd: projectRoot,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+
+  if (result.status !== 0) {
+    console.error(`\n✖️  ${stepName} failed. Please fix the problem above and try again.`);
+    process.exit(result.status ?? 1);
+  }
+}
+
+function ensureEnvFile() {
+  const envPath = path.join(projectRoot, '.env');
+  const examplePath = path.join(projectRoot, '.env.example');
+
+  if (fs.existsSync(envPath)) {
+    return;
+  }
+
+  if (fs.existsSync(examplePath)) {
+    fs.copyFileSync(examplePath, envPath);
+    console.log("\n📄 Copied .env.example to .env for you.");
+  } else {
+    const template = ['OPENAI_API_KEY=', 'GEMINI_API_KEY='].join('\n');
+    fs.writeFileSync(envPath, `${template}\n`);
+    console.log("\n📄 Created a fresh .env file for you.");
+  }
+}
+
+console.log('Hello! I will set everything up for you.');
+
+runStep('Installing everything the app needs', 'npm', ['install']);
+
+ensureEnvFile();
+
+runStep('Saving your secret keys', process.execPath, [path.join('scripts', 'save-keys.js')]);
+
+console.log('\n✅ All done! Run "npm start" next, then open http://localhost:3000.');

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,125 @@
+const express = require('express');
+const path = require('path');
+const axios = require('axios');
+const multer = require('multer');
+const FormData = require('form-data');
+require('dotenv').config();
+
+const app = express();
+const upload = multer({ storage: multer.memoryStorage() });
+
+let fileKeys = {};
+try {
+  const loaded = require('./private-keys');
+  if (loaded && typeof loaded === 'object') {
+    fileKeys = loaded;
+  }
+} catch (err) {
+  if (err.code !== 'MODULE_NOT_FOUND') {
+    console.warn('Could not load server/private-keys.js:', err.message);
+  }
+}
+
+const OPENAI_API_KEY = (process.env.OPENAI_API_KEY || fileKeys.openai || '').trim();
+const GEMINI_API_KEY = (process.env.GEMINI_API_KEY || fileKeys.gemini || '').trim();
+
+app.use(express.json({ limit: '25mb' }));
+
+const staticDir = path.join(__dirname, '..');
+app.use(express.static(staticDir));
+
+function handleAxiosError(err, res) {
+  if (err.response) {
+    const { status, data } = err.response;
+    return res.status(status).json(data || { error: { message: 'Upstream request failed' } });
+  }
+  console.error(err);
+  return res.status(500).json({ error: { message: err.message || 'Proxy request failed' } });
+}
+
+app.get('/api/status', (req, res) => {
+  res.json({ openai: Boolean(OPENAI_API_KEY), gemini: Boolean(GEMINI_API_KEY) });
+});
+
+app.post('/api/openai/chat', async (req, res) => {
+  if (!OPENAI_API_KEY) {
+    return res.status(500).json({ error: { message: 'OpenAI key not configured on server.' } });
+  }
+  try {
+    const response = await axios.post('https://api.openai.com/v1/chat/completions', req.body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+    });
+    res.json(response.data);
+  } catch (err) {
+    handleAxiosError(err, res);
+  }
+});
+
+app.post('/api/openai/transcriptions', upload.single('file'), async (req, res) => {
+  if (!OPENAI_API_KEY) {
+    return res.status(500).json({ error: { message: 'OpenAI key not configured on server.' } });
+  }
+  if (!req.file) {
+    return res.status(400).json({ error: { message: 'Missing audio file.' } });
+  }
+  try {
+    const form = new FormData();
+    const filename = req.file.originalname || 'audio.webm';
+    form.append('file', req.file.buffer, { filename });
+    Object.entries(req.body || {}).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach(v => form.append(key, v));
+      } else {
+        form.append(key, value);
+      }
+    });
+    const response = await axios.post('https://api.openai.com/v1/audio/transcriptions', form, {
+      headers: {
+        ...form.getHeaders(),
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+    });
+    res.json(response.data);
+  } catch (err) {
+    handleAxiosError(err, res);
+  }
+});
+
+app.post('/api/gemini/movement', async (req, res) => {
+  if (!GEMINI_API_KEY) {
+    return res.status(500).json({ error: { message: 'Gemini key not configured on server.' } });
+  }
+  const { model, prompt, transcript, video } = req.body || {};
+  if (!video?.data || !video?.mimeType || !prompt || !transcript) {
+    return res.status(400).json({ error: { message: 'Missing movement analysis payload.' } });
+  }
+  const targetModel = model || 'gemini-1.5-flash';
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${targetModel}:generateContent?key=${GEMINI_API_KEY}`;
+  const payload = {
+    contents: [
+      {
+        role: 'user',
+        parts: [
+          { text: prompt },
+          { inlineData: { mimeType: video.mimeType, data: video.data } },
+          { text: `Transcript:\n${transcript}` },
+        ],
+      },
+    ],
+    generationConfig: { maxOutputTokens: 512 },
+  };
+  try {
+    const response = await axios.post(url, payload);
+    res.json(response.data);
+  } catch (err) {
+    handleAxiosError(err, res);
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`MT academy server running on port ${PORT}`);
+});

--- a/server/private-keys.js
+++ b/server/private-keys.js
@@ -1,0 +1,11 @@
+/**
+ * Paste your private API keys in this file.
+ * Only the Node.js server reads this file, so the browser never sees the values.
+ * Replace the placeholder text with your real keys and keep them secret.
+ */
+module.exports = {
+  /** Your OpenAI key (starts with "sk-") */
+  openai: 'sk-your-openai-key-goes-here',
+  /** Your Gemini key (leave as an empty string if you are not using Gemini) */
+  gemini: 'your-gemini-key-goes-here',
+};


### PR DESCRIPTION
## Summary
- add a `server/private-keys.js` helper so the proxy can read API keys directly from a local file
- update the Express server to fall back to that file when environment variables are missing
- rewrite the README with simple instructions that only require pasting keys in one spot before running the app

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68cf6c68f3248331b6a1f4feb7a54da3