### PR TITLE
Remove notable voice moments from voice feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -2287,9 +2287,6 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
         <div>Speed</div><div>${escHTML(a.speedRating)} (${a.wpm} WPM)</div>
       </div>`;
       voiceHTML+=`<div class="small" style="margin-top:4px"><strong>Voice Tips:</strong> ${escHTML(a.tips)}</div>`;
-      if(a.points&&a.points.length){
-        voiceHTML+=`<div class="small"><strong>Notable Voice Moments:</strong> ${escHTML(a.points.join('; '))}</div>`;
-      }
     }
     html+=`<div id="voiceFeedback" style="display:none;margin-top:8px">${voiceHTML}</div>`;
     $('videoFeedback').innerHTML=html;


### PR DESCRIPTION
## Summary
- remove the "Notable Voice Moments" display from the Show Voice panel while preserving volume, tone, clarity, and speed details

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d4c3bb343c8331a1c6c0519f4454f3