### PR TITLE
Clarify opposing counsel instructions in objections drill

### DIFF
--- a/index.html
+++ b/index.html
@@ -1712,11 +1712,12 @@ function model(){if(!cur)return;const r=$('objResult');r.hidden=false;$('objRuli
  const systemMsg = {
   role: 'system',
   content:
- `${STATES[CURRENT_STATE].judgePrompt}
+`${STATES[CURRENT_STATE].judgePrompt}
 You are acting as opposing counsel in a mock trial objection argument.
 Constraints (must follow):
 - Do NOT invent or add any facts, events, injuries, statements, or timelines beyond the SCENARIO block.
 - Do NOT use hypotheticals or "for example" stories.
+- Never issue a ruling or act like the judge. Do NOT say phrases such as "sustained," "overruled," or "move on." Your role is only to argue against the user's objection as opposing counsel.
 - If the question lacks foundation or requires inference beyond the SCENARIO, object on that basis (e.g., Rule 602 speculation, Rule 611, etc.) WITHOUT adding facts.
 - Avoid Rule 602 objections unless the lack of personal knowledge is unmistakable; prefer other rules or no objection when foundation appears sufficient.
 - Keep responses concise, transcript-style (1–3 sentences), grounded ONLY in the SCENARIO facts and the rules of evidence.`


### PR DESCRIPTION
## Summary
- reinforce the ChatGPT objections mode system prompt so the assistant stays in the opposing-counsel role
- explicitly forbid the model from issuing rulings such as "sustained" or "overruled"

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4c63900b08331b9d41fe4c5da84bd