### PR TITLE
Adjust ChatGPT scoring prompts for varied ranges

### DIFF
--- a/index.html
+++ b/index.html
@@ -849,7 +849,7 @@ PENALTIES / GUARDRAILS
 FORMAT TO RETURN
 Provide:
 Summary: cite at least 3 specific quotes or paraphrases from different parts of the transcript.
-Score Range: two numbers from 1–10 (high minus low exactly 1.0; respect the floors above).
+Score Range: two numbers from 1–10. Pick a spread that reflects how confident you are (typically 0.4–1.5 apart) and only use a wider range when the performance is inconsistent. Avoid repeating the same range across responses and ensure the range matches the transcript's quality.
 Explanation: 2–4 sentences with one actionable fix (e.g., “name 801(d)(2) and request limiting instruction”).
 
 CHECKLIST THE JUDGE MUST APPLY (internally)
@@ -877,7 +877,7 @@ const PROMPT_TEMPLATE =
 `2. Summarize the transcript in detail, citing at least three direct quotes \n`+
 `   or paraphrased references from different parts of the transcript to \n`+
 `   demonstrate you read all of it.\n`+
-`3. Assign a score range from 1 to 10 using the rubric above (rate “I don't know” or non-answers as 1). The high and low must differ by exactly 1.0.\n`+
+`3. Assign a score range from 1 to 10 using the rubric above (rate “I don't know” or non-answers as 1). Choose the high-low spread to reflect your confidence (usually 0.4–1.5 difference) and avoid defaulting to the same numbers.\n`+
 `4. Consider coherence, evidence, clarity, and persuasiveness. The rating \n`+
 `   should reflect the transcript and not default to a midpoint score.\n`+
 `5. Base all judgments strictly on explicit content from the transcript. Do not guess or assume facts not in evidence; if information is missing, treat it as a deficiency and score accordingly.\n`+
@@ -889,7 +889,7 @@ const PROMPT_TEMPLATE =
 `9. State any assumptions you made.\n\n`+
 `Format your response as:\n`+
 `Summary: <detailed summary with references>\n`+
-`Score Range: <low-high from 1 to 10 with one decimal place (e.g., 7.5-8.5). High minus low exactly 1.0>\n`+
+`Score Range: <low-high from 1 to 10 with one decimal place (e.g., 7.6-8.4). Pick a spread that reflects confidence (generally 0.4–1.5 apart) and vary it based on performance.>\n`+
 `Explanation: <short paragraph explaining the score>\n`+
 `Assumptions: <assumptions or "None">\n`+
 `Improvements: <specific, actionable suggestions>`;
@@ -904,7 +904,7 @@ const PROMPT_TEMPLATE_RULING =
 `2. Summarize the transcript in detail, citing at least three direct quotes \n`+
 `   or paraphrased references from different parts of the transcript to \n`+
 `   demonstrate you read all of it.\n`+
-`3. Assign a score range from 1 to 10 using the rubric above (rate “I don't know” or non-answers as 1). The high and low must differ by exactly 1.0.\n`+
+`3. Assign a score range from 1 to 10 using the rubric above (rate “I don't know” or non-answers as 1). Choose the high-low spread to reflect your confidence (usually 0.4–1.5 difference) and avoid defaulting to the same numbers.\n`+
 `4. Consider coherence, evidence, clarity, and persuasiveness. The rating \n`+
 `   should reflect the transcript and not default to a midpoint score.\n`+
 `5. Base all judgments strictly on explicit content from the transcript. Do not guess or assume facts not in evidence; if information is missing, treat it as a deficiency and score accordingly.\n`+
@@ -918,12 +918,12 @@ const PROMPT_TEMPLATE_RULING =
 `Format your response as:\n`+
 `Ruling: <Sustained or Overruled>\n`+
 `Summary: <detailed summary with references>\n`+
-`Score Range: <low-high from 1 to 10 with one decimal place (e.g., 7.5-8.5). High minus low exactly 1.0>\n`+
+`Score Range: <low-high from 1 to 10 with one decimal place (e.g., 7.6-8.4). Pick a spread that reflects confidence (generally 0.4–1.5 apart) and vary it based on performance.>\n`+
 `Explanation: <short paragraph explaining the score>\n`+
 `Assumptions: <assumptions or "None">\n`+
 `Improvements: <specific, actionable suggestions>`;
 
-  const PROMPT_PREFIX = "Important: Score realistically as a high school regional judge. Use the entire 1-10 scale and give the score the transcript truly earns. Keep overall scores typically above 7 only when the work merits it; award 9s and 10s only for genuinely standout performances, and reserve 6s or lower for performances that are very weak or contain major flaws. Always provide a concrete score that reflects the transcript and include the required low-high range with a 1.0 spread. When performances are weak, do not hesitate to assign scores in the 1-5 range. Avoid defaulting to the same range over and over; vary the score to match the transcript's strengths and weaknesses. Provide precise decimals when helpful (e.g., 7.3, 8.1) but do not alter a score just to dodge a round number. If the transcript is disorganized, inaccurate, or lacks key elements from the rubric, lower the score accordingly. Double-check all rule citations and facts for accuracy.";
+  const PROMPT_PREFIX = "Important: Score realistically as a high school regional judge. Use the entire 1-10 scale and give the score the transcript truly earns. Keep overall scores typically above 7 only when the work merits it; award 9s and 10s only for genuinely standout performances, and reserve 6s or lower for performances that are very weak or contain major flaws. Always provide a concrete score that reflects the transcript and include a low-high range whose spread mirrors your confidence (usually 0.4–1.5 apart, wider only when the performance is uneven). When performances are weak, do not hesitate to assign scores in the 1-5 range. Avoid defaulting to the same range over and over; vary the score to match the transcript's strengths and weaknesses. Provide precise decimals when helpful (e.g., 7.3, 8.1) but do not alter a score just to dodge a round number. If the transcript is disorganized, inaccurate, or lacks key elements from the rubric, lower the score accordingly. Double-check all rule citations and facts for accuracy.";
 
   function buildScoringPrompt(transcript, includeRuling=false, rubric=RATING_RUBRIC){
     let cleaned = transcript.trim();
@@ -1060,7 +1060,7 @@ function makeRubricMap(stateName, abbr){
   \u25a1 Discussed the burden of proof
   \u25a1 Presentation was non-argumentative; did not analyze law or facts, draw conclusions, assume facts not in evidence, or otherwise argue
   \u25a1 Spoke naturally and clearly
-  Return strict JSON: {"total":0-100,"range":"0-100","categories":{"content":1-10,"organization":1-10,"persuasion":1-10,"delivery":1-10},"comments":{"content":"","organization":"","persuasion":"","delivery":""},"explanation":"2-3 sentences noting strengths and weaknesses","notes":"at least two actionable tips separated by \n"}. Range must be "low-high" with high minus low exactly 10. Total must equal weighted sum of category scores (rounded).`,
+  Return strict JSON: {"total":0-100,"range":"0-100","categories":{"content":1-10,"organization":1-10,"persuasion":1-10,"delivery":1-10},"comments":{"content":"","organization":"","persuasion":"","delivery":""},"explanation":"2-3 sentences noting strengths and weaknesses","notes":"at least two actionable tips separated by \n"}. Range must be "low-high" (e.g., "74.0-80.5") with a spread that mirrors confidence—typically 6-12 points apart, wider only if performance quality varies greatly. Total must equal weighted sum of category scores (rounded).`,
     closing:`Rate a CLOSING ARGUMENT using the ${stateName} State and Regional Tournament judges rubric. Score it as a judge would at a regional tournament. If the material is good, do not hesitate to award a 9 or 10 (90/100 or 100/100). Categories/weights:
   - Content & Law Application (35)
   - Structure & Element Walk-through (20)
@@ -1079,7 +1079,7 @@ function makeRubricMap(stateName, abbr){
   \u25a1 Use of notes was minimal, effective, and purposeful
   \u25a1 Contained spontaneous elements that reflect unanticipated outcomes of this specific trial
   \u25a1 Spoke naturally and clearly
-  Return JSON: {"total":0-100,"range":"0-100","categories":{"content":1-10,"organization":1-10,"refutation":1-10,"persuasion":1-10,"delivery":1-10},"comments":{"content":"","organization":"","refutation":"","persuasion":"","delivery":""},"explanation":"2-3 sentences noting strengths and weaknesses","notes":"at least two actionable tips separated by \n"}. Range must be "low-high" with high minus low exactly 10. Total must equal weighted sum (rounded).`,
+  Return JSON: {"total":0-100,"range":"0-100","categories":{"content":1-10,"organization":1-10,"refutation":1-10,"persuasion":1-10,"delivery":1-10},"comments":{"content":"","organization":"","refutation":"","persuasion":"","delivery":""},"explanation":"2-3 sentences noting strengths and weaknesses","notes":"at least two actionable tips separated by \n"}. Range must be "low-high" (e.g., "72.5-80.0") with a confidence-based spread of roughly 6-12 points, varying as needed. Total must equal weighted sum (rounded).`,
     direct:`Rate a DIRECT EXAMINATION using the ${stateName} State and Regional Tournament judges rubric. Score it as a judge would at a regional tournament. If the material is good, do not hesitate to award a 9 or 10 (90/100 or 100/100). Categories/weights:
   - Chapters & Story Build (30)
   - Open-Ended Technique (20)
@@ -1097,7 +1097,7 @@ function makeRubricMap(stateName, abbr){
   \u25a1 Demonstrated an understanding of the Modified Federal Rules of Evidence
   \u25a1 Handled physical evidence appropriately and effectively
   \u25a1 Spoke confidently and clearly
-  Analyze each question and answer pair; for each pair provide qScore (1-10) with qReason, and aScore (1-10) with aReason. Return JSON: {"total":0-100,"range":"0-100","categories":{"content":1-10,"openq":1-10,"foundation":1-10,"listening":1-10,"delivery":1-10},"comments":{"content":"","openq":"","foundation":"","listening":"","delivery":""},"qa":[{"q":"","a":"","qScore":1-10,"qReason":"","aScore":1-10,"aReason":""}],"explanation":"2-3 sentences noting strengths and weaknesses","notes":"at least two actionable tips separated by \n"}. Range must be "low-high" with high minus low exactly 10. Total must equal weighted sum (rounded).`,
+  Analyze each question and answer pair; for each pair provide qScore (1-10) with qReason, and aScore (1-10) with aReason. Return JSON: {"total":0-100,"range":"0-100","categories":{"content":1-10,"openq":1-10,"foundation":1-10,"listening":1-10,"delivery":1-10},"comments":{"content":"","openq":"","foundation":"","listening":"","delivery":""},"qa":[{"q":"","a":"","qScore":1-10,"qReason":"","aScore":1-10,"aReason":""}],"explanation":"2-3 sentences noting strengths and weaknesses","notes":"at least two actionable tips separated by \n"}. Range must be "low-high" with a confidence-based spread (roughly 6-12 points unless the performance justifies more). Total must equal weighted sum (rounded).`,
     cross:`Rate a CROSS EXAMINATION using the ${stateName} State and Regional Tournament judges rubric. Score it as a judge would at a regional tournament. If the material is good, do not hesitate to award a 9 or 10 (90/100 or 100/100). Categories/weights:
   - Chapters & Damage Theory (30)
   - Leading & Control (25)
@@ -1117,7 +1117,7 @@ function makeRubricMap(stateName, abbr){
   \u25a1 Demonstrated an understanding of the Modified Federal Rules of Evidence
   \u25a1 Handled physical evidence appropriately and effectively
   \u25a1 Spoke confidently and clearly
-  Analyze each question and answer pair; for each pair provide qScore (1-10) with qReason, and aScore (1-10) with aReason. Return JSON: {"total":0-100,"range":"0-100","categories":{"content":1-10,"leading":1-10,"impeach":1-10,"brevity":1-10,"delivery":1-10},"comments":{"content":"","leading":"","impeach":"","brevity":"","delivery":""},"qa":[{"q":"","a":"","qScore":1-10,"qReason":"","aScore":1-10,"aReason":""}],"explanation":"2-3 sentences noting strengths and weaknesses","notes":"at least two actionable tips separated by \n"}. Range must be "low-high" with high minus low exactly 10. Total must equal weighted sum (rounded).`
+  Analyze each question and answer pair; for each pair provide qScore (1-10) with qReason, and aScore (1-10) with aReason. Return JSON: {"total":0-100,"range":"0-100","categories":{"content":1-10,"leading":1-10,"impeach":1-10,"brevity":1-10,"delivery":1-10},"comments":{"content":"","leading":"","impeach":"","brevity":"","delivery":""},"qa":[{"q":"","a":"","qScore":1-10,"qReason":"","aScore":1-10,"aReason":""}],"explanation":"2-3 sentences noting strengths and weaknesses","notes":"at least two actionable tips separated by \n"}. Range must be "low-high" with a spread that reflects confidence (roughly 6-12 points by default). Total must equal weighted sum (rounded).`
   };
 }
 


### PR DESCRIPTION
## Summary
- relax the scoring prompt instructions so ChatGPT can pick confidence-based score spreads instead of a fixed 1-point range
- update the JSON rubric prompts to require varied percentage ranges rather than the default 10-point span
- reinforce guidance to avoid recycling the same range and tie the spread to transcript quality

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9bdd3e9788331a8ee57db292f4de8