### PR TITLE
Clarify legal meaning of argumentative objection for scoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -806,6 +806,7 @@ const ChatGPTScoring = (() => {
   const ARGUMENT_RUBRIC = `Mock Trial Objection & Argument Rubric — High-Confidence Scoring (10 pts total)
 
 Goal: Reward correct, concise, fact-grounded advocacy. Do NOT midpoint-anchor. Start from the category floors below and adjust only as directed.
+Remember that “argumentative” is a Rule 611(a) objection about questions that argue with or harass the witness; do not confuse it with the everyday notion of someone sounding combative.
 If the argument is strong, do not hesitate to award 9 or 10 points (90/100 or 100/100). Use scores below 9 only when notable deficiencies appear, and reserve sub-7 scores for arguments that are exceptionally brief or poor.
 
 CATEGORIES (sum to 10)


### PR DESCRIPTION
## Summary
- clarify the rubric language so the scoring assistant treats "argumentative" as the Rule 611(a) objection rather than the colloquial tone critique

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c27ee7088331b8fff6e7f2bb9a40