### PR TITLE
Normalize legacy Gemini model identifiers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1022,11 +1022,21 @@ function escHTML(s){return s?String(s).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'
 function normalizeGeminiModel(value){
   const fallback=GEMINI_DEFAULT_MODEL;
   if(!value) return fallback;
+  let v=String(value).trim();
+  if(!v) return fallback;
+  if(v.startsWith('models/')) v=v.slice(7);
   const map={
     'gemini-1.5-flash': 'gemini-1.5-flash-latest',
-    'gemini-1.5-pro': 'gemini-1.5-pro-latest'
+    'gemini-1.5-pro': 'gemini-1.5-pro-latest',
+    'gemini-pro': 'gemini-1.5-pro-latest',
+    'gemini-pro-latest': 'gemini-1.5-pro-latest',
+    'gemini-pro-vision': 'gemini-1.5-pro-latest',
+    'gemini-pro-vision-latest': 'gemini-1.5-pro-latest',
+    'gemini-1.0-pro': 'gemini-1.5-pro-latest',
+    'gemini-1.0-pro-vision': 'gemini-1.5-pro-latest',
+    'gemini-1.0-pro-vision-latest': 'gemini-1.5-pro-latest'
   };
-  return map[value]||value;
+  return map[v]||v;
 }
 
 function attachFollowupSender(id, handler){


### PR DESCRIPTION
## Summary
- trim and normalize saved Gemini model ids before use
- strip legacy models/ prefixes and map deprecated ids to supported defaults

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9fc6a225c8331bdf681c12d134d8d