### PR TITLE
Fix Gemini movement analysis payload

### DIFF
--- a/index.html
+++ b/index.html
@@ -3591,8 +3591,13 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
         return callGemini({
           model,
           contents:[
-            {role:'user',parts:[{text:prompt}]},
-            {role:'user',parts:[{text: `${prefix}Transcript:\n` + transcript}]}
+            {
+              role:'user',
+              parts:[
+                {text:prompt},
+                {text: `${prefix}Transcript:\n${transcript}`}
+              ]
+            }
           ],
           generationConfig:{maxOutputTokens:512,temperature:0.25,topP:0.9},
           retries:1
@@ -3611,9 +3616,14 @@ Which brings me to the third reason, the mistakes of the Phoenix PD. Detective A
       }else{
         const b64 = await blobToBase64(lastVideoBlob);
         const videoContents = [
-          { role: 'user', parts: [ { text: prompt } ] },
-          { role: 'user', parts: [ { inlineData: { mimeType: mime, data: b64 } } ] },
-          { role: 'user', parts: [ { text: 'Transcript:\n' + transcript } ] }
+          {
+            role: 'user',
+            parts: [
+              { text: prompt },
+              { inlineData: { mimeType: mime, data: b64 } },
+              { text: 'Transcript:\n' + transcript }
+            ]
+          }
         ];
         try{
           text = await callGemini({


### PR DESCRIPTION
## Summary
- group the Gemini movement prompt, video, and transcript into a single turn
- ensure transcript-only fallbacks send one user message with both instructions and transcript

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da0b52c6108331a2354c7098351693