### PR TITLE
Add catch block for scoreViaChatGPT try statement

### DIFF
--- a/index.html
+++ b/index.html
@@ -3650,6 +3650,15 @@ ${transcript}`
       }
 
       return result;
+    } catch (err) {
+      console.error('[scoreViaChatGPT]', err);
+      const error = err instanceof Error ? err : new Error(err?.message || 'scoreViaChatGPT failed');
+      if (err && typeof err === 'object' && 'raw' in err && err.raw && typeof err.raw === 'string' && !('raw' in error)) {
+        error.raw = err.raw;
+      } else if (rawText && typeof rawText === 'string' && !('raw' in error)) {
+        error.raw = rawText;
+      }
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary
- add a catch block to scoreViaChatGPT so the try statement is balanced and browsers no longer throw a syntax error
- surface the underlying raw response when available before rethrowing to aid debugging

## Testing
- not run (HTML change only)


------
https://chatgpt.com/codex/tasks/task_e_68db54fbb9208331a6d989c4306096b9