### PR TITLE
Hide objection score output

### DIFF
--- a/index.html
+++ b/index.html
@@ -1575,9 +1575,12 @@ function appendJudgeDecision(res){
   sum.innerHTML=`<strong>Summary:</strong> ${escHTML(res.summary)}`;
   div.appendChild(sum);
  }
- const score=document.createElement('div');
- score.innerHTML=`<strong>Score Range:</strong> ${escHTML(res.score)}`;
- div.appendChild(score);
+ if(res.score){
+  const score=document.createElement('div');
+  score.hidden=true;
+  score.innerHTML=`<strong>Score Range:</strong> ${escHTML(res.score)}`;
+  div.appendChild(score);
+ }
  const explain=document.createElement('div');
  explain.innerHTML=`<strong>Explanation:</strong> ${escHTML(res.explanation)}`;
  div.appendChild(explain);


### PR DESCRIPTION
## Summary
- hide the ChatGPT score range in the objection drill chat while preserving the underlying data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e31ed98d008331bbfb0d58eb4fbb51