### PR TITLE
Remove quiz mode selector from rules quiz

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,7 +338,6 @@ a.inline{color:var(--accent);text-decoration:underline}
   <section id="quiz" class="card">
     <h2>Rules Quiz</h2>
     <div class="controls small">
-      <label>Mode: <select id="quizMode"><option value="mix">Mixed</option><option value="titleFromNumber">Title from Number</option><option value="numberFromTitle">Number from Title</option></select></label>
       <label>Rules: <select id="quizScope"><option value="all">All</option><option value="hearsay">Hearsay</option><option value="character">Character Evidence</option><option value="witness">Witness Testimony</option></select></label>
       <label>Questions: <select id="quizCount"><option>5</option><option>10</option><option>15</option></select></label>
       <label>Difficulty: <select id="quizDifficulty"><option value="1">Standard</option><option value="2">Hard (subsections)</option></select></label>
@@ -4839,7 +4838,7 @@ function qSub(){
 
 function show(){
  $('quizBody').innerHTML=''; $('quizExplain').textContent='';
-  mode=$('quizMode').value; section=$('quizScope')?$('quizScope').value:'all'; difficulty=parseInt(($('quizDifficulty')?.value||'1'),10);
+  mode='mix'; section=$('quizScope')?$('quizScope').value:'all'; difficulty=parseInt(($('quizDifficulty')?.value||'1'),10);
   current=(difficulty===2)?qSub():qBasic();
   const wrap=document.createElement('div');
    const q=document.createElement('div'); q.className='quiz-q'; q.textContent=current.q; wrap.appendChild(q);


### PR DESCRIPTION
## Summary
- remove the quiz mode dropdown from the rules quiz controls
- default the quiz logic to the mixed question mode now that the selector is gone

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e321a43b088331804e2b7adeb130f5