### PR TITLE
Integrate new how-to layout with hub

### DIFF
--- a/howto.html
+++ b/howto.html
@@ -223,6 +223,12 @@
       font-weight: 600;
     }
 
+    .section-chip.active {
+      background: rgba(56, 189, 248, 0.3);
+      border-color: rgba(56, 189, 248, 0.55);
+      color: #f8fafc;
+    }
+
     .section-chip:hover,
     .section-chip:focus-visible {
       transform: translateY(-1px);
@@ -490,36 +496,36 @@
       <p>Browse the highlights below or jump straight to the full apps using the shortcut tiles. Each practice space opens in its own tab so you can experiment without losing progress.</p>
       <nav class="anchor-nav" aria-label="Page sections">
         <ul>
-          <li><a href="#overview">Quick Start</a></li>
-          <li><a href="#objections">Objections Drill</a></li>
-          <li><a href="#video-coach">Video Coach</a></li>
-          <li><a href="#writing">Writing Lab</a></li>
-          <li><a href="#rules">Rules Library</a></li>
-          <li><a href="#quiz">Rules Quiz</a></li>
-          <li><a href="#api">OpenAI API Keys</a></li>
+          <li><a href="#howto-overview">Quick Start</a></li>
+          <li><a href="#howto-objections">Objections Drill</a></li>
+          <li><a href="#howto-video-coach">Video Coach</a></li>
+          <li><a href="#howto-writing">Writing Lab</a></li>
+          <li><a href="#howto-rules">Rules Library</a></li>
+          <li><a href="#howto-quiz">Rules Quiz</a></li>
+          <li><a href="#howto-api">OpenAI API Keys</a></li>
         </ul>
       </nav>
       <div class="section-chips" role="list" aria-label="Jump to sections">
-        <a class="section-chip" href="#overview" role="listitem"><span>01</span> Quick Start</a>
-        <a class="section-chip" href="#objections" role="listitem"><span>02</span> Objections</a>
-        <a class="section-chip" href="#video-coach" role="listitem"><span>03</span> Video Coach</a>
-        <a class="section-chip" href="#writing" role="listitem"><span>04</span> Writing Lab</a>
-        <a class="section-chip" href="#rules" role="listitem"><span>05</span> Rules Library</a>
-        <a class="section-chip" href="#quiz" role="listitem"><span>06</span> Rules Quiz</a>
-        <a class="section-chip" href="#api" role="listitem"><span>07</span> API Keys</a>
+        <a class="section-chip" href="#howto-overview" role="listitem"><span>01</span> Quick Start</a>
+        <a class="section-chip" href="#howto-objections" role="listitem"><span>02</span> Objections</a>
+        <a class="section-chip" href="#howto-video-coach" role="listitem"><span>03</span> Video Coach</a>
+        <a class="section-chip" href="#howto-writing" role="listitem"><span>04</span> Writing Lab</a>
+        <a class="section-chip" href="#howto-rules" role="listitem"><span>05</span> Rules Library</a>
+        <a class="section-chip" href="#howto-quiz" role="listitem"><span>06</span> Rules Quiz</a>
+        <a class="section-chip" href="#howto-api" role="listitem"><span>07</span> API Keys</a>
       </div>
     </header>
 
     <main class="content">
-      <section id="overview" class="card highlight">
+      <section id="howto-overview" class="card highlight">
         <h2>Quick Start</h2>
         <p>Decide what skill you want to sharpen, then launch the matching tool. You can move between apps freely—your progress and generated drafts stay in their tabs until you clear them.</p>
-        <p>If you plan to use ChatGPT scoring, drafting, or movement analysis, create your own OpenAI API key before jumping into drills (see <a href="#api">API Keys</a> below). Each tile includes a shortcut to its how-to section and a direct launch link.</p>
+        <p>If you plan to use ChatGPT scoring, drafting, or movement analysis, create your own OpenAI API key before jumping into drills (see <a href="#howto-api">API Keys</a> below). Each tile includes a shortcut to its how-to section and a direct launch link.</p>
         <div class="info-grid" aria-label="Tool shortcuts">
           <article class="info-tile">
             <div class="info-header">
               <strong>Objections Drill</strong>
-              <a class="info-link info-link--howto" href="#objections" aria-label="Read how to use the Objections Drill">
+              <a class="info-link info-link--howto" href="#howto-objections" aria-label="Read how to use the Objections Drill">
                 <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
                 How-to
               </a>
@@ -532,7 +538,7 @@
           <article class="info-tile">
             <div class="info-header">
               <strong>Video Coach</strong>
-              <a class="info-link info-link--howto" href="#video-coach" aria-label="Read how to use the Video Coach">
+              <a class="info-link info-link--howto" href="#howto-video-coach" aria-label="Read how to use the Video Coach">
                 <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
                 How-to
               </a>
@@ -545,7 +551,7 @@
           <article class="info-tile">
             <div class="info-header">
               <strong>Writing Lab</strong>
-              <a class="info-link info-link--howto" href="#writing" aria-label="Read how to use the Writing Lab">
+              <a class="info-link info-link--howto" href="#howto-writing" aria-label="Read how to use the Writing Lab">
                 <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
                 How-to
               </a>
@@ -558,7 +564,7 @@
           <article class="info-tile">
             <div class="info-header">
               <strong>Rules Library</strong>
-              <a class="info-link info-link--howto" href="#rules" aria-label="Read how to use the Rules Library">
+              <a class="info-link info-link--howto" href="#howto-rules" aria-label="Read how to use the Rules Library">
                 <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
                 How-to
               </a>
@@ -571,7 +577,7 @@
           <article class="info-tile">
             <div class="info-header">
               <strong>Rules Quiz</strong>
-              <a class="info-link info-link--howto" href="#quiz" aria-label="Read how to use the Rules Quiz">
+              <a class="info-link info-link--howto" href="#howto-quiz" aria-label="Read how to use the Rules Quiz">
                 <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
                 How-to
               </a>
@@ -584,7 +590,7 @@
           <article class="info-tile">
             <div class="info-header">
               <strong>API Keys Portal</strong>
-              <a class="info-link info-link--howto" href="#api" aria-label="Read how to set up API keys">
+              <a class="info-link info-link--howto" href="#howto-api" aria-label="Read how to set up API keys">
                 <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
                 How-to
               </a>
@@ -597,7 +603,7 @@
         </div>
       </section>
 
-    <section id="objections" class="card">
+    <section id="howto-objections" class="card">
       <h2>Objections Drill</h2>
       <ol>
         <li>Set the topic, difficulty, and prompt style (built-in scenario or fresh AI prompt).</li>
@@ -605,11 +611,11 @@
         <li>Click <em>Check</em> to compare your answer with the expected objection and rule citation.</li>
         <li>Use <em>ChatGPT Argue</em> to practice explaining your reasoning in real time.</li>
         <li>Press <em>Score</em> to receive detailed feedback from ChatGPT on the strength of your argument.</li>
-        <li>Need a refresher on objection lists? Open the <a href="rules.html">Rules Library</a> in another tab.</li>
+        <li>Need a refresher on objection lists? Open the <a href="rules.html" data-section="rules">Rules Library</a> in another tab.</li>
       </ol>
     </section>
 
-    <section id="video-coach" class="card">
+    <section id="howto-video-coach" class="card">
       <h2>Video Coach</h2>
       <ol>
         <li>Choose the speech type you want to rehearse, then hit <em>Start Recording</em>.</li>
@@ -622,66 +628,76 @@
       </ol>
     </section>
 
-    <section id="writing" class="card">
+    <section id="howto-writing" class="card">
       <h2>Writing Lab</h2>
       <ol>
         <li>Pick a document type (opening, closing, cross, etc.) and jot down the facts or themes you want to highlight.</li>
         <li>Click <em>Ask ChatGPT to Draft</em> to generate a sample passage tailored to your notes.</li>
         <li>Edit the draft directly in the browser, then copy it into your preferred editor or team folder.</li>
-        <li>Pair your draft with a <a href="rules.html">rule citation</a> or <a href="objections.html">objection drill</a> to stress-test your argument.</li>
+        <li>Pair your draft with a <a href="rules.html" data-section="rules">rule citation</a> or <a href="objections.html" data-section="objections">objection drill</a> to stress-test your argument.</li>
       </ol>
     </section>
 
-    <section id="rules" class="card">
+    <section id="howto-rules" class="card">
       <h2>Rules Library</h2>
       <ol>
         <li>Search by rule number, keyword, or topic. Results update instantly.</li>
         <li>Select a rule to read the full text along with a short explanation.</li>
         <li>Use <em>Clear</em> to reset your search or open the <em>Official PDF</em> for the complete rulebook.</li>
-        <li>Need a pop quiz on what you just read? Jump to the <a href="quiz.html">Rules Quiz</a> without leaving your browser.</li>
+        <li>Need a pop quiz on what you just read? Jump to the <a href="quiz.html" data-section="quiz">Rules Quiz</a> without leaving your browser.</li>
       </ol>
     </section>
 
-    <section id="quiz" class="card">
+    <section id="howto-quiz" class="card">
       <h2>Rules Quiz</h2>
       <ol>
         <li>Choose a mode (standard or lightning), the rule sets you want to review, question count, and difficulty.</li>
         <li>Press <em>Start Quiz</em> to begin. Each question appears one at a time—answer, then click <em>Next</em>.</li>
         <li>Track your accuracy with the live score display and revisit tricky rules with the review links.</li>
-        <li>Run a rematch after reviewing the <a href="rules.html">Rules Library</a> to lock in those citations.</li>
+        <li>Run a rematch after reviewing the <a href="rules.html" data-section="rules">Rules Library</a> to lock in those citations.</li>
       </ol>
     </section>
 
-    <section id="api" class="card">
+    <section id="howto-api" class="card">
       <h2>OpenAI API Keys</h2>
       <ol>
         <li>Log in at <a href="https://platform.openai.com/">platform.openai.com</a> using your own account.</li>
         <li>Visit the <a href="https://platform.openai.com/account/billing/overview">Billing dashboard</a> and add a payment method so ChatGPT requests can process.</li>
         <li>Open the <a href="https://platform.openai.com/api-keys">API Keys page</a> and click <strong>Create new secret key</strong>.</li>
-        <li>Copy the key into MT academy's <a href="api-keys.html">API Key portal</a>, choose a model, and hit <em>Save ChatGPT Key</em>.</li>
+        <li>Copy the key into MT academy's <a href="api-keys.html" data-section="keys">API Key portal</a>, choose a model, and hit <em>Save ChatGPT Key</em>.</li>
         <li>Return to any tool and click <em>Test ChatGPT</em> (or the equivalent button) to confirm everything works.</li>
       </ol>
       <p>Keep your key private. You can remove it at any time with the <em>Remove</em> button on the API Keys page.</p>
       <div class="callout" role="note">
         <strong>Need help?</strong>
-        <span>OpenAI bills by usage. You can monitor spending on the <a href="https://platform.openai.com/account/usage">Usage dashboard</a> and set alerts there. For MT academy-specific questions, reach out through the <a href="contact.html">contact form</a>.</span>
+        <span>OpenAI bills by usage. You can monitor spending on the <a href="https://platform.openai.com/account/usage">Usage dashboard</a> and set alerts there. For MT academy-specific questions, reach out through the <a href="contact.html" data-section="contact">contact form</a>.</span>
       </div>
       </section>
     </main>
 
     <footer class="footer">
-      <p>Back to the <a href="index.html#howto">main How to section</a> or explore other tools from the <a href="index.html">home page</a>. Want rules at a glance? Jump into the <a href="rules.html">Rules Library</a>, and when you're ready to practice live, start a <a href="video-coach.html">Video Coach</a> session.</p>
+      <p>Back to the <a href="index.html#howto">main How to section</a> or explore other tools from the <a href="index.html">home page</a>. Want rules at a glance? Jump into the <a href="rules.html" data-section="rules">Rules Library</a>, and when you're ready to practice live, start a <a href="video-coach.html" data-section="video">Video Coach</a> session.</p>
     </footer>
   </div>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const navLinks = Array.from(document.querySelectorAll('.anchor-nav a'));
+      const chipLinks = Array.from(document.querySelectorAll('.section-chips a'));
       const sections = navLinks
         .map((link) => document.querySelector(link.getAttribute('href')))
         .filter(Boolean);
 
       const activateLink = (id) => {
         navLinks.forEach((link) => {
+          const isActive = link.getAttribute('href') === `#${id}`;
+          link.classList.toggle('active', isActive);
+          if (isActive) {
+            link.setAttribute('aria-current', 'location');
+          } else {
+            link.removeAttribute('aria-current');
+          }
+        });
+        chipLinks.forEach((link) => {
           const isActive = link.getAttribute('href') === `#${id}`;
           link.classList.toggle('active', isActive);
         });

--- a/index.html
+++ b/index.html
@@ -118,6 +118,52 @@ a.inline{color:var(--accent);text-decoration:underline}
 .hidden-link{color:inherit;text-decoration:none}
 .title-block h1{color:#e2e8f0}
 .title-block .small,.title-block p{color:rgba(226,232,240,.9)}
+#howto.card{padding:0;background:transparent;border:none;box-shadow:none}
+#howto .page-shell{position:relative;width:min(1100px,92vw);margin:0 auto;padding:clamp(2.5rem,6vw,4rem) clamp(1.5rem,4vw,3rem) 3rem;display:flex;flex-direction:column;gap:clamp(2rem,5vw,3rem)}
+#howto .glow{position:absolute;inset:clamp(1rem,3vw,2.5rem);border-radius:28px;background:linear-gradient(135deg,rgba(56,189,248,.08),rgba(14,165,233,.03));border:1px solid rgba(148,163,184,.16);backdrop-filter:blur(22px);pointer-events:none}
+#howto .hero,#howto .content,#howto .footer{position:relative;z-index:1}
+#howto .hero{background:linear-gradient(135deg,rgba(56,189,248,.16),rgba(14,165,233,.08));border-radius:24px;padding:clamp(1.8rem,5vw,2.75rem);border:1px solid rgba(56,189,248,.25);box-shadow:0 25px 60px rgba(15,23,42,.4);display:flex;flex-direction:column;gap:1rem}
+#howto .hero h1,#howto .hero h2{margin:0;font-size:clamp(2.2rem,5vw,3rem);letter-spacing:-.02em}
+#howto .hero p{margin:0;color:var(--muted);max-width:60ch}
+#howto .hero p+p{font-size:.95rem;max-width:65ch;opacity:.9}
+#howto .eyebrow{font-size:.85rem;letter-spacing:.2em;text-transform:uppercase;color:#bae6fd;font-weight:600}
+#howto .anchor-nav ul{list-style:none;margin:0;padding:0;display:flex;flex-wrap:wrap;gap:.75rem}
+#howto .anchor-nav a{display:inline-flex;align-items:center;gap:.5rem;padding:.55rem .95rem;border-radius:999px;border:1px solid rgba(56,189,248,.35);background:rgba(15,23,42,.6);color:var(--text);text-decoration:none;font-size:.95rem;transition:transform .2s ease,box-shadow .2s ease,background .2s ease}
+#howto .anchor-nav a:hover,#howto .anchor-nav a:focus{transform:translateY(-2px);box-shadow:0 12px 30px rgba(56,189,248,.25);background:rgba(56,189,248,.2);outline:none}
+#howto .anchor-nav a.active{background:rgba(56,189,248,.32);box-shadow:0 16px 36px rgba(14,165,233,.24);color:#f0f9ff}
+#howto .section-chips{display:flex;flex-wrap:wrap;gap:.65rem;padding:.5rem 0 0}
+#howto .section-chip{position:relative;display:inline-flex;align-items:center;gap:.4rem;padding:.5rem .85rem;border-radius:14px;background:rgba(15,23,42,.72);border:1px solid rgba(148,163,184,.2);text-decoration:none;color:var(--muted);font-size:.85rem;transition:transform .2s ease,background .2s ease,border .2s ease}
+#howto .section-chip span{display:inline-flex;align-items:center;justify-content:center;width:1.45rem;height:1.45rem;border-radius:50%;background:rgba(56,189,248,.18);color:#bae6fd;font-size:.7rem;font-weight:600}
+#howto .section-chip.active{background:rgba(56,189,248,.3);border-color:rgba(56,189,248,.55);color:#f8fafc}
+#howto .section-chip:hover,#howto .section-chip:focus-visible{transform:translateY(-1px);background:rgba(56,189,248,.18);border-color:rgba(56,189,248,.45);color:#f8fafc;outline:none}
+#howto .content{display:grid;gap:clamp(1.5rem,4vw,2.5rem)}
+#howto .content>.card{display:block;background:rgba(15,23,42,.88);border-radius:22px;padding:clamp(1.6rem,4vw,2.4rem);border:1px solid rgba(148,163,184,.18);box-shadow:0 25px 60px rgba(15,23,42,.4);position:relative;overflow:hidden}
+#howto .content>.card h2{margin-top:0;font-size:clamp(1.45rem,3vw,1.85rem);letter-spacing:-.01em;display:inline-flex;align-items:center;gap:.55rem}
+#howto .content>.card h2::before{content:"";width:10px;height:10px;border-radius:999px;background:var(--accent);box-shadow:0 0 12px rgba(56,189,248,.6)}
+#howto .content>.card::after{content:"";position:absolute;inset:0;background:radial-gradient(120% 140% at 100% 0%,rgba(56,189,248,.18),transparent 55%);opacity:0;transition:opacity .3s ease;pointer-events:none}
+#howto .content>.card:hover::after,#howto .content>.card:focus-within::after{opacity:1}
+#howto .content>.card p,#howto .content>.card ol{color:var(--muted)}
+#howto .content>.card ol{margin:0;padding-left:1.1rem;display:grid;gap:.75rem}
+#howto .content>.card li{line-height:1.6}
+#howto .content>.card.highlight{background:linear-gradient(135deg,rgba(56,189,248,.14),rgba(37,99,235,.22));border:1px solid rgba(56,189,248,.45)}
+#howto .info-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1.15rem;margin-top:1.35rem}
+#howto .info-tile{border-radius:18px;border:1px solid rgba(125,211,252,.35);background:rgba(8,47,73,.4);padding:1.2rem 1.35rem;display:flex;flex-direction:column;gap:.85rem;min-height:100%;transition:transform .2s ease,box-shadow .2s ease,border .2s ease}
+#howto .info-tile:hover,#howto .info-tile:focus-within{transform:translateY(-4px);box-shadow:0 20px 46px rgba(14,165,233,.32);border-color:rgba(56,189,248,.55)}
+#howto .info-header{display:flex;justify-content:space-between;align-items:center;gap:.75rem}
+#howto .info-header strong{font-size:1.05rem;color:var(--text);letter-spacing:-.01em}
+#howto .info-summary{color:rgba(226,232,240,.8);font-size:.9rem;line-height:1.5;margin:0}
+#howto .info-actions{display:flex;flex-wrap:wrap;gap:.6rem}
+#howto .info-link{display:inline-flex;align-items:center;gap:.35rem;padding:.45rem .85rem;border-radius:999px;text-decoration:none;font-size:.85rem;font-weight:500;transition:background .2s ease,color .2s ease}
+#howto .info-link svg{width:.85rem;height:.85rem}
+#howto .info-link--howto{background:rgba(56,189,248,.18);color:#e0f2fe;border:1px solid rgba(56,189,248,.4)}
+#howto .info-link--howto:hover,#howto .info-link--howto:focus-visible{background:rgba(56,189,248,.3);color:#f8fafc;outline:none}
+#howto .info-link--launch{background:rgba(15,23,42,.7);color:rgba(191,219,254,.9);border:1px solid rgba(148,163,184,.3)}
+#howto .info-link--launch:hover,#howto .info-link--launch:focus-visible{background:rgba(15,23,42,.92);color:#f8fafc;border-color:rgba(191,219,254,.6);outline:none}
+#howto .callout{border-radius:18px;border:1px dashed rgba(125,211,252,.4);background:rgba(15,118,110,.18);padding:1.1rem 1.3rem;color:#ccfbf1;font-size:.95rem;display:grid;gap:.4rem}
+#howto .callout strong{color:#5eead4;text-transform:uppercase;letter-spacing:.1em;font-size:.75rem}
+#howto .footer{text-align:center;color:var(--muted);font-size:.95rem}
+#howto .footer a{font-weight:600}
+@media(max-width:640px){#howto .page-shell{padding:1.75rem 1.1rem 2.5rem}#howto .content>.card{padding:1.5rem}#howto .info-header{flex-direction:column;align-items:flex-start}#howto .info-actions{width:100%}#howto .info-link{width:fit-content}}
 </style>
 </head>
 <body>
@@ -387,58 +433,199 @@ a.inline{color:var(--accent);text-decoration:underline}
     </div>
   </section>
   <!-- How To -->
-  <section id="howto" class="card">
-    <h2>How to Use</h2>
-    <p class="small">Open a tab for the tool you need and follow these steps.</p>
-    <ul class="small">
-      <li>
-        <a href="objections.html" class="hidden-link"><strong>Objections:</strong></a>
-        <ul class="small">
-          <li>Pick a topic and difficulty.</li>
-          <li><em>New Drill</em> gives a built‑in objection.</li>
-          <li><em>GPT Prompt</em> asks ChatGPT to craft a new one.</li>
-          <li>Select the objection you would make, then press <em>Check</em>.</li>
-          <li><em>ChatGPT Argue</em> debates your reasoning with ChatGPT.</li>
-          <li><em>Score</em> lets ChatGPT grade your argument.</li>
-        </ul>
-      </li>
-      <li>
-        <a href="video-coach.html" class="hidden-link"><strong>Video Coach:</strong></a>
-        <ul class="small">
-          <li>Select the speech type and click <em>Start Recording</em>.</li>
-          <li>Use <em>Stop</em> when done, then <em>Play</em> or <em>Download</em> to review.</li>
-          <li><em>Re-score</em> analyzes delivery; <em>Show Voice</em> displays the transcript.</li>
-          <li><em>Movement (ChatGPT)</em> reviews posture and gestures; <em>API Key / Engine</em> adds keys.</li>
-          <li>If the movement request is too large or unsupported, the tool automatically falls back to transcript-only guidance.</li>
-          <li><em>Test ChatGPT</em> confirms your key works.</li>
-        </ul>
-      </li>
-      <li>
-        <a href="writing.html" class="hidden-link"><strong>Writing:</strong></a>
-        <ul class="small">
-          <li>Choose a document type and add notes.</li>
-          <li>Press <em>Ask ChatGPT to Draft</em> for a sample.</li>
-          <li>Edit the output and save it however you like.</li>
-        </ul>
-      </li>
-      <li>
-        <a href="rules.html" class="hidden-link"><strong>Rules:</strong></a>
-        <ul class="small">
-          <li>Search by number or topic.</li>
-          <li>Use <em>Clear</em> to reset or open the <em>Official PDF</em>.</li>
-          <li>Click a rule to read the full text and explanation.</li>
-        </ul>
-      </li>
-      <li>
-        <a href="quiz.html" class="hidden-link"><strong>Rules Quiz:</strong></a>
-        <ul class="small">
-          <li>Select mode, rules, question count, and difficulty.</li>
-          <li>Press <em>Start Quiz</em>, answer, then click <em>Next</em> for the following question.</li>
-          <li>Track your progress with the score display.</li>
-        </ul>
-      </li>
-    </ul>
-    <p class="small">To use ChatGPT features—including transcript scoring, video-based movement coaching, and drafting tools—create your own OpenAI API key and add funds to your account. See the API Keys page for step-by-step setup.</p>
+  <section id="howto" class="card howto-host">
+    <div class="page-shell">
+      <div class="glow" aria-hidden="true"></div>
+      <header class="hero">
+        <span class="eyebrow">MT academy Playbook</span>
+        <h2 style="margin:0">How to Use MT academy</h2>
+        <p>Every MT academy tool shares the same goal: make it easier to prepare for mock trial. Use this guide for a quick refresher, to onboard teammates, or to map out your next practice session.</p>
+        <p>Browse the highlights below or jump straight to the full apps using the shortcut tiles. Each practice space opens in its own tab so you can experiment without losing progress.</p>
+        <nav class="anchor-nav" aria-label="Page sections">
+          <ul>
+            <li><a href="#howto-overview">Quick Start</a></li>
+            <li><a href="#howto-objections">Objections Drill</a></li>
+            <li><a href="#howto-video-coach">Video Coach</a></li>
+            <li><a href="#howto-writing">Writing Lab</a></li>
+            <li><a href="#howto-rules">Rules Library</a></li>
+            <li><a href="#howto-quiz">Rules Quiz</a></li>
+            <li><a href="#howto-api">OpenAI API Keys</a></li>
+          </ul>
+        </nav>
+        <div class="section-chips" role="list" aria-label="Jump to sections">
+          <a class="section-chip" href="#howto-overview" role="listitem"><span>01</span> Quick Start</a>
+          <a class="section-chip" href="#howto-objections" role="listitem"><span>02</span> Objections</a>
+          <a class="section-chip" href="#howto-video-coach" role="listitem"><span>03</span> Video Coach</a>
+          <a class="section-chip" href="#howto-writing" role="listitem"><span>04</span> Writing Lab</a>
+          <a class="section-chip" href="#howto-rules" role="listitem"><span>05</span> Rules Library</a>
+          <a class="section-chip" href="#howto-quiz" role="listitem"><span>06</span> Rules Quiz</a>
+          <a class="section-chip" href="#howto-api" role="listitem"><span>07</span> API Keys</a>
+        </div>
+      </header>
+
+      <div class="content">
+        <section id="howto-overview" class="card highlight">
+          <h2>Quick Start</h2>
+          <p>Decide what skill you want to sharpen, then launch the matching tool. You can move between apps freely—your progress and generated drafts stay in their tabs until you clear them.</p>
+          <p>If you plan to use ChatGPT scoring, drafting, or movement analysis, create your own OpenAI API key before jumping into drills (see <a href="#howto-api">API Keys</a> below). Each tile includes a shortcut to its how-to section and a direct launch link.</p>
+          <div class="info-grid" aria-label="Tool shortcuts">
+            <article class="info-tile">
+              <div class="info-header">
+                <strong>Objections Drill</strong>
+                <a class="info-link info-link--howto" href="#howto-objections" aria-label="Read how to use the Objections Drill">
+                  <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
+                  How-to
+                </a>
+              </div>
+              <p class="info-summary">Practice fast objections with built-in fact patterns or AI-generated prompts.</p>
+              <div class="info-actions">
+                <a class="info-link info-link--launch" href="objections.html">Launch tool</a>
+              </div>
+            </article>
+            <article class="info-tile">
+              <div class="info-header">
+                <strong>Video Coach</strong>
+                <a class="info-link info-link--howto" href="#howto-video-coach" aria-label="Read how to use the Video Coach">
+                  <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
+                  How-to
+                </a>
+              </div>
+              <p class="info-summary">Record and score speeches with movement analysis plus delivery feedback.</p>
+              <div class="info-actions">
+                <a class="info-link info-link--launch" href="video-coach.html">Launch tool</a>
+              </div>
+            </article>
+            <article class="info-tile">
+              <div class="info-header">
+                <strong>Writing Lab</strong>
+                <a class="info-link info-link--howto" href="#howto-writing" aria-label="Read how to use the Writing Lab">
+                  <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
+                  How-to
+                </a>
+              </div>
+              <p class="info-summary">Draft openings, closings, and crosses using your notes and ChatGPT assists.</p>
+              <div class="info-actions">
+                <a class="info-link info-link--launch" href="writing.html">Launch tool</a>
+              </div>
+            </article>
+            <article class="info-tile">
+              <div class="info-header">
+                <strong>Rules Library</strong>
+                <a class="info-link info-link--howto" href="#howto-rules" aria-label="Read how to use the Rules Library">
+                  <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
+                  How-to
+                </a>
+              </div>
+              <p class="info-summary">Search the NCHSAA rules instantly and save citations for competition.</p>
+              <div class="info-actions">
+                <a class="info-link info-link--launch" href="rules.html">Launch tool</a>
+              </div>
+            </article>
+            <article class="info-tile">
+              <div class="info-header">
+                <strong>Rules Quiz</strong>
+                <a class="info-link info-link--howto" href="#howto-quiz" aria-label="Read how to use the Rules Quiz">
+                  <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
+                  How-to
+                </a>
+              </div>
+              <p class="info-summary">Challenge yourself or teammates with custom quizzes and lightning rounds.</p>
+              <div class="info-actions">
+                <a class="info-link info-link--launch" href="quiz.html">Launch tool</a>
+              </div>
+            </article>
+            <article class="info-tile">
+              <div class="info-header">
+                <strong>API Keys Portal</strong>
+                <a class="info-link info-link--howto" href="#howto-api" aria-label="Read how to set up API keys">
+                  <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
+                  How-to
+                </a>
+              </div>
+              <p class="info-summary">Securely store, test, or remove the OpenAI keys used across every tool.</p>
+              <div class="info-actions">
+                <a class="info-link info-link--launch" href="api-keys.html">Launch tool</a>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section id="howto-objections" class="card">
+          <h2>Objections Drill</h2>
+          <ol>
+            <li>Set the topic, difficulty, and prompt style (built-in scenario or fresh AI prompt).</li>
+            <li>Read the fact pattern, select the best objection, and note the supporting rule.</li>
+            <li>Click <em>Check</em> to compare your answer with the expected objection and rule citation.</li>
+            <li>Use <em>ChatGPT Argue</em> to practice explaining your reasoning in real time.</li>
+            <li>Press <em>Score</em> to receive detailed feedback from ChatGPT on the strength of your argument.</li>
+            <li>Need a refresher on objection lists? Open the <a href="rules.html" data-section="rules">Rules Library</a> in another tab.</li>
+          </ol>
+        </section>
+
+        <section id="howto-video-coach" class="card">
+          <h2>Video Coach</h2>
+          <ol>
+            <li>Choose the speech type you want to rehearse, then hit <em>Start Recording</em>.</li>
+            <li>After finishing, click <em>Stop</em>, then review or download your video.</li>
+            <li>Select <em>Re-score</em> for updated delivery notes and <em>Show Voice</em> to review the transcript.</li>
+            <li>Use <em>Movement (ChatGPT)</em> for posture and gesture analysis—large uploads automatically fall back to transcript coaching.</li>
+            <li>Confirm your API configuration anytime with <em>Test ChatGPT</em> in the toolbar.</li>
+            <li>Final results appear as a rating (Terrible → Amazing) with specific action items to try in your next run.</li>
+            <li>Want to benchmark progress? Log each rehearsal in your team tracker or share the download with coaches.</li>
+          </ol>
+        </section>
+
+        <section id="howto-writing" class="card">
+          <h2>Writing Lab</h2>
+          <ol>
+            <li>Pick a document type (opening, closing, cross, etc.) and jot down the facts or themes you want to highlight.</li>
+            <li>Click <em>Ask ChatGPT to Draft</em> to generate a sample passage tailored to your notes.</li>
+            <li>Edit the draft directly in the browser, then copy it into your preferred editor or team folder.</li>
+            <li>Pair your draft with a <a href="rules.html" data-section="rules">rule citation</a> or <a href="objections.html" data-section="objections">objection drill</a> to stress-test your argument.</li>
+          </ol>
+        </section>
+
+        <section id="howto-rules" class="card">
+          <h2>Rules Library</h2>
+          <ol>
+            <li>Search by rule number, keyword, or topic. Results update instantly.</li>
+            <li>Select a rule to read the full text along with a short explanation.</li>
+            <li>Use <em>Clear</em> to reset your search or open the <em>Official PDF</em> for the complete rulebook.</li>
+            <li>Need a pop quiz on what you just read? Jump to the <a href="quiz.html" data-section="quiz">Rules Quiz</a> without leaving your browser.</li>
+          </ol>
+        </section>
+
+        <section id="howto-quiz" class="card">
+          <h2>Rules Quiz</h2>
+          <ol>
+            <li>Choose a mode (standard or lightning), the rule sets you want to review, question count, and difficulty.</li>
+            <li>Press <em>Start Quiz</em> to begin. Each question appears one at a time—answer, then click <em>Next</em>.</li>
+            <li>Track your accuracy with the live score display and revisit tricky rules with the review links.</li>
+            <li>Run a rematch after reviewing the <a href="rules.html" data-section="rules">Rules Library</a> to lock in those citations.</li>
+          </ol>
+        </section>
+
+        <section id="howto-api" class="card">
+          <h2>OpenAI API Keys</h2>
+          <ol>
+            <li>Log in at <a href="https://platform.openai.com/">platform.openai.com</a> using your own account.</li>
+            <li>Visit the <a href="https://platform.openai.com/account/billing/overview">Billing dashboard</a> and add a payment method so ChatGPT requests can process.</li>
+            <li>Open the <a href="https://platform.openai.com/api-keys">API Keys page</a> and click <strong>Create new secret key</strong>.</li>
+            <li>Copy the key into MT academy's <a href="api-keys.html" data-section="keys">API Key portal</a>, choose a model, and hit <em>Save ChatGPT Key</em>.</li>
+            <li>Return to any tool and click <em>Test ChatGPT</em> (or the equivalent button) to confirm everything works.</li>
+          </ol>
+          <p>Keep your key private. You can remove it at any time with the <em>Remove</em> button on the API Keys page.</p>
+          <div class="callout" role="note">
+            <strong>Need help?</strong>
+            <span>OpenAI bills by usage. You can monitor spending on the <a href="https://platform.openai.com/account/usage">Usage dashboard</a> and set alerts there. For MT academy-specific questions, reach out through the <a href="contact.html" data-section="contact">contact form</a>.</span>
+          </div>
+        </section>
+      </div>
+
+      <footer class="footer">
+        <p>Back to the <a href="#howto-overview">top of this guide</a> or explore other tools from the main navigation. Want rules at a glance? Jump into the <a href="rules.html" data-section="rules">Rules Library</a>, and when you're ready to practice live, start a <a href="video-coach.html" data-section="video">Video Coach</a> session.</p>
+      </footer>
+    </div>
   </section>
   <!-- Contact -->
   <section id="contact" class="card">
@@ -4913,7 +5100,7 @@ document.addEventListener('DOMContentLoaded',()=>{
     $('rulesHeading').textContent=`${STATES[CURRENT_STATE].abbr} HS Mock Trial Rules of Evidence \u2014 Explorer`;
   });
 
-  const sections=Array.from(document.querySelectorAll('section.card'));
+  const sections=Array.from(document.querySelectorAll('.app > section.card'));
   function showSection(id){
     sections.forEach(sec=>sec.style.display=sec.id===id?'block':'none');
     document.querySelectorAll('#navMenu .tab').forEach(link=>{
@@ -4930,6 +5117,73 @@ document.addEventListener('DOMContentLoaded',()=>{
     if(id==='video'){ maybeShowVideoGate(); }
   }
 
+  function initHowTo(initialHash){
+    const howto=$('howto');
+    if(!howto) return;
+    const navLinks=Array.from(howto.querySelectorAll('.anchor-nav a'));
+    const chipLinks=Array.from(howto.querySelectorAll('.section-chips a'));
+    const observeSections=navLinks
+      .map(link=>{
+        const href=link.getAttribute('href');
+        if(!href || !href.startsWith('#')) return null;
+        return howto.querySelector(href);
+      })
+      .filter(Boolean);
+
+    const activate=id=>{
+      navLinks.forEach(link=>{
+        const match=link.getAttribute('href')===`#${id}`;
+        link.classList.toggle('active',match);
+        if(match){link.setAttribute('aria-current','location');}
+        else{link.removeAttribute('aria-current');}
+      });
+      chipLinks.forEach(link=>{
+        const match=link.getAttribute('href')===`#${id}`;
+        link.classList.toggle('active',match);
+      });
+    };
+
+    if(observeSections.length){
+      activate(observeSections[0].id);
+      const observer=new IntersectionObserver(entries=>{
+        entries.filter(entry=>entry.isIntersecting).forEach(entry=>activate(entry.target.id));
+      },{rootMargin:'-45% 0px -45% 0px',threshold:.1});
+      observeSections.forEach(section=>observer.observe(section));
+    }
+
+    howto.querySelectorAll('a[href^="#howto-"]').forEach(link=>{
+      link.addEventListener('click',evt=>{
+        const href=link.getAttribute('href');
+        if(!href) return;
+        const target=howto.querySelector(href);
+        if(target){
+          evt.preventDefault();
+          target.scrollIntoView({behavior:'smooth',block:'start'});
+          activate(target.id);
+        }
+      });
+    });
+
+    howto.querySelectorAll('a[data-section]').forEach(link=>{
+      link.addEventListener('click',evt=>{
+        const target=link.getAttribute('data-section');
+        if(target){
+          evt.preventDefault();
+          showSection(target);
+        }
+      });
+    });
+
+    if(initialHash && initialHash.startsWith('howto-')){
+      const target=howto.querySelector(`#${initialHash}`);
+      if(target){
+        target.scrollIntoView({behavior:'auto',block:'start'});
+        activate(initialHash);
+        if(history.replaceState){history.replaceState(null,'',`#${initialHash}`);}
+      }
+    }
+  }
+
   document.querySelectorAll('#navMenu .tab').forEach(link=>{
     link.addEventListener('click',e=>{
       e.preventDefault();
@@ -4940,8 +5194,11 @@ document.addEventListener('DOMContentLoaded',()=>{
     });
   });
 
-  const initialHash=location.hash.slice(1) || 'howto';
+  const topLevelIds=sections.map(sec=>sec.id);
+  const rawHash=location.hash.slice(1);
+  const initialHash=topLevelIds.includes(rawHash)?rawHash:'howto';
   showSection(initialHash);
+  initHowTo(rawHash);
 
   document.querySelectorAll('a.hidden-link').forEach(link=>{
     link.addEventListener('click',e=>{


### PR DESCRIPTION
## Summary
- update howto.html ids and links so the refreshed layout can be embedded elsewhere without conflicts
- replace the legacy how-to card in index.html with the new interactive guide, including scoped styles and navigation logic
- add index-side scripting to sync in-page navigation, preserve deep links, and route helper links to the appropriate app sections

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e45c508c9483318d719d6f3b4cc270