### PR TITLE
Update how-to hero title and remove quick link section

### DIFF
--- a/howto.html
+++ b/howto.html
@@ -10,7 +10,7 @@
     gtag('config', 'G-3QMGWMD9KZ');
   </script>
   <meta charset="utf-8">
-  <title>How to Use MT academy</title>
+  <title>How to Use MT Academy</title>
   <meta name="description" content="Step-by-step instructions for every MT academy practice tool, including Objections, Video Coach, Writing, Rules, Rules Quiz, and OpenAI API key setup for ChatGPT scoring and movement analysis.">
   <meta name="keywords" content="mock trial, mock trial practice, mock trial resources, mock trial quizzes, high school mock trial, mock trial coaching, mock trial competition, MT academy">
   <meta name="robots" content="index, follow">
@@ -19,7 +19,7 @@
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="shortcut icon" href="/favicon.svg" type="image/svg+xml">
   <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
-  <meta property="og:title" content="How to Use MT academy">
+  <meta property="og:title" content="How to Use MT Academy">
   <meta property="og:description" content="Step-by-step instructions for every MT academy practice tool, including Objections, Video Coach, Writing, Rules, Rules Quiz, and OpenAI API key setup for ChatGPT scoring and movement analysis.">
   <meta property="og:url" content="https://mocktrialacademy.com/howto.html">
   <meta property="og:type" content="website">
@@ -470,7 +470,7 @@
   {
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "name": "How to Use MT academy",
+    "name": "How to Use MT Academy",
     "url": "https://mocktrialacademy.com/howto.html",
     "description": "Step-by-step instructions for every MT academy practice tool, including Objections, Video Coach, Writing, Rules, Rules Quiz, and OpenAI API key setup for ChatGPT scoring and movement analysis.",
     "keywords": [
@@ -490,30 +490,7 @@
   <div class="page-shell">
     <div class="glow" aria-hidden="true"></div>
     <header class="hero">
-      <span class="eyebrow">MT academy Playbook</span>
-      <h1>How to Use MT academy</h1>
-      <p>Every MT academy tool shares the same goal: make it easier to prepare for mock trial. Use this guide for a quick refresher, to onboard teammates, or to map out your next practice session.</p>
-      <p>Browse the highlights below or jump straight to the full apps using the shortcut tiles. Each practice space opens in its own tab so you can experiment without losing progress.</p>
-      <nav class="anchor-nav" aria-label="Page sections">
-        <ul>
-          <li><a href="#howto-overview">Quick Start</a></li>
-          <li><a href="#howto-objections">Objections Drill</a></li>
-          <li><a href="#howto-video-coach">Video Coach</a></li>
-          <li><a href="#howto-writing">Writing Lab</a></li>
-          <li><a href="#howto-rules">Rules Library</a></li>
-          <li><a href="#howto-quiz">Rules Quiz</a></li>
-          <li><a href="#howto-api">OpenAI API Keys</a></li>
-        </ul>
-      </nav>
-      <div class="section-chips" role="list" aria-label="Jump to sections">
-        <a class="section-chip" href="#howto-overview" role="listitem"><span>01</span> Quick Start</a>
-        <a class="section-chip" href="#howto-objections" role="listitem"><span>02</span> Objections</a>
-        <a class="section-chip" href="#howto-video-coach" role="listitem"><span>03</span> Video Coach</a>
-        <a class="section-chip" href="#howto-writing" role="listitem"><span>04</span> Writing Lab</a>
-        <a class="section-chip" href="#howto-rules" role="listitem"><span>05</span> Rules Library</a>
-        <a class="section-chip" href="#howto-quiz" role="listitem"><span>06</span> Rules Quiz</a>
-        <a class="section-chip" href="#howto-api" role="listitem"><span>07</span> API Keys</a>
-      </div>
+      <h1>How to Use MT Academy</h1>
     </header>
 
     <main class="content">


### PR DESCRIPTION
## Summary
- update the how-to page metadata and hero title to use "How to Use MT Academy"
- remove the playbook eyebrow from the hero banner while keeping the rest of the layout intact
- strip the hero description, nav, and shortcut chips so the page now opens with only the title before the Quick Start section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e45fb175c88331b4b3d3592d7e838a