### PR TITLE
Keep visited links the same lighter blue

### DIFF
--- a/api-keys.html
+++ b/api-keys.html
@@ -45,6 +45,10 @@
     ]
   }
   </script>
+  <style>
+    a,a:visited,a:active{color:#60a5fa;text-decoration:underline}
+    a:hover,a:focus{color:#93c5fd}
+  </style>
 </head>
 <body>
   <h1>API Keys / Engine</h1>

--- a/contact.html
+++ b/contact.html
@@ -45,6 +45,10 @@
     ]
   }
   </script>
+  <style>
+    a,a:visited,a:active{color:#60a5fa;text-decoration:underline}
+    a:hover,a:focus{color:#93c5fd}
+  </style>
 </head>
 <body>
   <h1>Contact</h1>

--- a/howto.html
+++ b/howto.html
@@ -26,6 +26,9 @@
   <meta property="og:site_name" content="MT academy">
   <meta property="og:locale" content="en_US">
   <style>
+    a,a:visited,a:active{color:#60a5fa;text-decoration:underline}
+    a:hover,a:focus{color:#93c5fd}
+
     :root {
       --bg: linear-gradient(135deg, #0f172a 55%, #1d4ed8);
       --surface: rgba(15, 23, 42, 0.92);

--- a/index.html
+++ b/index.html
@@ -47,12 +47,15 @@
 </script>
 <style>
 /* Refreshed blue & white palette */
-:root{--bg:linear-gradient(135deg,#0f172a 58%,#1d4ed8);--card:rgba(15,23,42,.92);--surface:#1e2a48;--muted:#cbd5f5;--text:#ffffff;--accent:#38bdf8;--secondary:#1d4ed8;--border:linear-gradient(135deg,#2563eb,#38bdf8)}
+:root{--bg:linear-gradient(135deg,#0f172a 58%,#1d4ed8);--card:rgba(15,23,42,.92);--surface:#1e2a48;--muted:#cbd5f5;--text:#ffffff;--accent:#38bdf8;--secondary:#1d4ed8;--link:#60a5fa;--border:linear-gradient(135deg,#2563eb,#38bdf8)}
 
 @media (prefers-color-scheme: dark){
-  :root{--bg:#0b1120;--card:rgba(15,23,42,.94);--surface:#1b2540;--muted:#cbd5f5;--text:#f8fafc;--accent:#38bdf8;--secondary:#1d4ed8;--border:linear-gradient(135deg,#60a5fa,#38bdf8)}
+  :root{--bg:#0b1120;--card:rgba(15,23,42,.94);--surface:#1b2540;--muted:#cbd5f5;--text:#f8fafc;--accent:#38bdf8;--secondary:#1d4ed8;--link:#60a5fa;--border:linear-gradient(135deg,#60a5fa,#38bdf8)}
 }
-*{box-sizing:border-box}body{margin:0;font-size:100%;font-family:Inter,system-ui,Segoe UI,Roboto,Arial;background:var(--bg);color:var(--text);min-height:100vh;border:12px solid transparent;border-image:var(--border) 1;text-shadow:none}
+*{box-sizing:border-box}
+a,a:visited,a:active{color:var(--link);text-decoration:underline}
+a:hover,a:focus{color:#93c5fd}
+body{margin:0;font-size:100%;font-family:Inter,system-ui,Segoe UI,Roboto,Arial;background:var(--bg);color:var(--text);min-height:100vh;border:12px solid transparent;border-image:var(--border) 1;text-shadow:none}
 .app{max-width:1100px;margin:18px auto;padding:16px}
 .header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:12px;position:relative}
 .title-block{flex:1}

--- a/objections.html
+++ b/objections.html
@@ -45,6 +45,10 @@
     ]
   }
   </script>
+  <style>
+    a,a:visited,a:active{color:#60a5fa;text-decoration:underline}
+    a:hover,a:focus{color:#93c5fd}
+  </style>
 </head>
 <body>
   <h1>Objections Drill</h1>

--- a/quiz.html
+++ b/quiz.html
@@ -45,6 +45,10 @@
     ]
   }
   </script>
+  <style>
+    a,a:visited,a:active{color:#60a5fa;text-decoration:underline}
+    a:hover,a:focus{color:#93c5fd}
+  </style>
 </head>
 <body>
   <h1>Rules Quiz</h1>

--- a/rules.html
+++ b/rules.html
@@ -45,6 +45,10 @@
     ]
   }
   </script>
+  <style>
+    a,a:visited,a:active{color:#60a5fa;text-decoration:underline}
+    a:hover,a:focus{color:#93c5fd}
+  </style>
 </head>
 <body>
   <h1>AZ HS Mock Trial Rules of Evidence</h1>

--- a/video-coach.html
+++ b/video-coach.html
@@ -45,6 +45,10 @@
     ]
   }
   </script>
+  <style>
+    a,a:visited,a:active{color:#60a5fa;text-decoration:underline}
+    a:hover,a:focus{color:#93c5fd}
+  </style>
 </head>
 <body>
   <h1>Video Coach</h1>

--- a/writing.html
+++ b/writing.html
@@ -45,6 +45,10 @@
     ]
   }
   </script>
+  <style>
+    a,a:visited,a:active{color:#60a5fa;text-decoration:underline}
+    a:hover,a:focus{color:#93c5fd}
+  </style>
 </head>
 <body>
   <h1>Writing New Materials</h1>


### PR DESCRIPTION
## Summary
- adjust the global link color to a brighter blue so links stay legible and never shift to purple after visiting
- apply the same link styling across auxiliary pages, including the active state, for consistent color treatment site-wide

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68e5cb79eda48331a6190120ef025551