### PR TITLE
Rename How-To page to HomePage

### DIFF
--- a/homepage.html
+++ b/homepage.html
@@ -10,18 +10,18 @@
     gtag('config', 'G-3QMGWMD9KZ');
   </script>
   <meta charset="utf-8">
-  <title>How to Use MT Academy</title>
+  <title>HomePage | MT Academy</title>
   <meta name="description" content="Step-by-step instructions for every MT academy practice tool, including Objections, Video Coach, Writing, Rules, Rules Quiz, and OpenAI API key setup for ChatGPT scoring and movement analysis.">
   <meta name="keywords" content="mock trial, mock trial practice, mock trial resources, mock trial quizzes, high school mock trial, mock trial coaching, mock trial competition, MT academy">
   <meta name="robots" content="index, follow">
-  <link rel="canonical" href="https://mocktrialacademy.com/howto.html">
+  <link rel="canonical" href="https://mocktrialacademy.com/homepage.html">
   <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAADvElEQVR4nMWWX2gcVRTGv3vnbrZ1Nds2TeOfjlJNs22Vxo3xwYJgHkLVRvsiZSNo17YSKk0kTfRFaYMUH2QmYKKsCgW1K1KlaoQ1EXzpSwjdNGJl4xqaNLRIG2KzNLQh2+7M8WF2ktmZmxIQdi4MDOd+c3/nnjnn3Msqv5mBQgYEig8ZJGBCsd4ddhMChmVfmivaJLplu+lcGwIGU2Aurc3LDIcCk5xr8zLD7Xey7dwH+NKGFZjgPsEtGwziPsKtX+An3EpCH+GuKig/XMC0q8AfuEIGuJ9wAQNCwEBuZCj7d+JYCo7x3Aefvb5BfbjaCZ/JjE3/qp8449TF3nl335ZIrdp3tDtxa35+AascH70Xf61WrdokciND2WhufDJL1OUU1NfXf13xypsvbNxsOTGTGZumP8+dJ5euqanpu58+/WRgemrqQE1NzT2rdSAajZ6K73liN+cwpYKurq7G7M/fjthh+/3H08Pd3d2NMi1bLdU1BAxwZQUHWltbt5nXLl+9nZu9eePKpdn7711baG5ufkSmffWtg3tr67Z+xRjT7UfX9VF7PpPJXHfOMcb0Q3u2767bvGGT4KCSxebm5hZDoVAgGAwq7e3t0eTQQPrW3PWbPcXdO+ftbxSY6NGOH7YTbuD71Fm3k+qDG6s+PrY/7k5mTwRyudxiMpkcB4C2tradV0ZH/ro988/VWCy2DQASicQfhUKh5COFzNL2Ko0qSSrJAOfkFeu6PkpECIfDwTfi+3d0dHREA4EAz+fzRn9//5hbz93t1RVVAGAED1zAhJDlwMTFyflUKjXV0tLyaGdn51OVlZUVAJBMJsdn/51ddOvd9S91APDCyYC0CtaEQms0TUsDgKqq94XD4SARobe397yiKFzqgKPJMIkDAHngVhWQVywqAuLCxMRCOp2+ZtsGBwcvLRTyaxljnqpbdqDYXiWbsiPghCsrlSED8OzLe3dpmrZUSpqmpZtfen6XZGvFNr7cXmURYCAP3EpCWcYS8PjTDZHC+vBWu25rG3Y8E4lsUeUOUMm5wSVRBeCBCzIh5OEiKDCxs/HJSENjX8R5sMgGJ+fBZK6QhOSFW7/g7t66TzVZ2/UsusJvdesEDLD2k6do8txw9pfPEykAWF9dve7tD3sO3u1IPdJxoi+fv3MHAI4fje2rr3tIdTeZL34YPnv6twujAPDYA+uqzrz/YtwNF2SAdZ78kv7XeS69K3izXQZX4LgT+gG3r2TML7ggg/EinPkBFyi9lrNywy0HSnfOygkXMPEfanF6PajmzH4AAAAASUVORK5CYII=">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="shortcut icon" href="/favicon.svg" type="image/svg+xml">
   <meta property="og:image" content="https://mocktrialacademy.com/favicon.svg">
-  <meta property="og:title" content="How to Use MT Academy">
+  <meta property="og:title" content="HomePage | MT Academy">
   <meta property="og:description" content="Step-by-step instructions for every MT academy practice tool, including Objections, Video Coach, Writing, Rules, Rules Quiz, and OpenAI API key setup for ChatGPT scoring and movement analysis.">
-  <meta property="og:url" content="https://mocktrialacademy.com/howto.html">
+  <meta property="og:url" content="https://mocktrialacademy.com/homepage.html">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="MT academy">
   <meta property="og:locale" content="en_US">
@@ -379,14 +379,14 @@
       height: 0.85rem;
     }
 
-    .info-link--howto {
+    .info-link--homepage {
       background: rgba(56, 189, 248, 0.18);
       color: #e0f2fe;
       border: 1px solid rgba(56, 189, 248, 0.4);
     }
 
-    .info-link--howto:hover,
-    .info-link--howto:focus-visible {
+    .info-link--homepage:hover,
+    .info-link--homepage:focus-visible {
       background: rgba(56, 189, 248, 0.3);
       color: #f8fafc;
       outline: none;
@@ -473,8 +473,8 @@
   {
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "name": "How to Use MT Academy",
-    "url": "https://mocktrialacademy.com/howto.html",
+    "name": "HomePage | MT Academy",
+    "url": "https://mocktrialacademy.com/homepage.html",
     "description": "Step-by-step instructions for every MT academy practice tool, including Objections, Video Coach, Writing, Rules, Rules Quiz, and OpenAI API key setup for ChatGPT scoring and movement analysis.",
     "keywords": [
       "mock trial",
@@ -493,21 +493,21 @@
   <div class="page-shell">
     <div class="glow" aria-hidden="true"></div>
     <header class="hero">
-      <h1>How to Use MT Academy</h1>
+      <h1>HomePage</h1>
     </header>
 
     <main class="content">
-      <section id="howto-overview" class="card highlight">
+      <section id="homepage-overview" class="card highlight">
         <h2>Quick Start</h2>
         <p>Decide what skill you want to sharpen, then launch the matching tool. You can move between apps freely—your progress and generated drafts stay in their tabs until you clear them.</p>
-        <p>If you plan to use ChatGPT scoring, drafting, or movement analysis, create your own OpenAI API key before jumping into drills (see <a href="#howto-api">API Keys</a> below). Each tile includes a shortcut to its how-to section and a direct launch link.</p>
+        <p>If you plan to use ChatGPT scoring, drafting, or movement analysis, create your own OpenAI API key before jumping into drills (see <a href="#homepage-api">API Keys</a> below). Each tile includes a shortcut to its detailed section and a direct launch link.</p>
         <div class="info-grid" aria-label="Tool shortcuts">
           <article class="info-tile">
             <div class="info-header">
               <strong>Objections Drill</strong>
-              <a class="info-link info-link--howto" href="#howto-objections" aria-label="Read how to use the Objections Drill">
+              <a class="info-link info-link--homepage" href="#homepage-objections" aria-label="Read about the Objections Drill">
                 <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
-                How-to
+                HomePage
               </a>
             </div>
             <p class="info-summary">Practice fast objections with built-in fact patterns or AI-generated prompts.</p>
@@ -518,9 +518,9 @@
           <article class="info-tile">
             <div class="info-header">
               <strong>Video Coach</strong>
-              <a class="info-link info-link--howto" href="#howto-video-coach" aria-label="Read how to use the Video Coach">
+              <a class="info-link info-link--homepage" href="#homepage-video-coach" aria-label="Read about the Video Coach">
                 <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
-                How-to
+                HomePage
               </a>
             </div>
             <p class="info-summary">Record and score speeches with movement analysis plus delivery feedback.</p>
@@ -531,9 +531,9 @@
           <article class="info-tile">
             <div class="info-header">
               <strong>Writing Lab</strong>
-              <a class="info-link info-link--howto" href="#howto-writing" aria-label="Read how to use the Writing Lab">
+              <a class="info-link info-link--homepage" href="#homepage-writing" aria-label="Read about the Writing Lab">
                 <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
-                How-to
+                HomePage
               </a>
             </div>
             <p class="info-summary">Draft openings, closings, and crosses using your notes and ChatGPT assists.</p>
@@ -544,9 +544,9 @@
           <article class="info-tile">
             <div class="info-header">
               <strong>Rules Library</strong>
-              <a class="info-link info-link--howto" href="#howto-rules" aria-label="Read how to use the Rules Library">
+              <a class="info-link info-link--homepage" href="#homepage-rules" aria-label="Read about the Rules Library">
                 <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
-                How-to
+                HomePage
               </a>
             </div>
             <p class="info-summary">Search the NCHSAA rules instantly and save citations for competition.</p>
@@ -557,9 +557,9 @@
           <article class="info-tile">
             <div class="info-header">
               <strong>Rules Quiz</strong>
-              <a class="info-link info-link--howto" href="#howto-quiz" aria-label="Read how to use the Rules Quiz">
+              <a class="info-link info-link--homepage" href="#homepage-quiz" aria-label="Read about the Rules Quiz">
                 <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
-                How-to
+                HomePage
               </a>
             </div>
             <p class="info-summary">Challenge yourself or teammates with custom quizzes and lightning rounds.</p>
@@ -570,9 +570,9 @@
           <article class="info-tile">
             <div class="info-header">
               <strong>API Keys Portal</strong>
-              <a class="info-link info-link--howto" href="#howto-api" aria-label="Read how to set up API keys">
+              <a class="info-link info-link--homepage" href="#homepage-api" aria-label="Read about setting up API keys">
                 <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
-                How-to
+                HomePage
               </a>
             </div>
             <p class="info-summary">Securely store, test, or remove the OpenAI keys used across every tool.</p>
@@ -583,7 +583,7 @@
         </div>
       </section>
 
-    <section id="howto-objections" class="card">
+    <section id="homepage-objections" class="card">
       <h2>Objections Drill</h2>
       <ol>
         <li>Set the topic, difficulty, and prompt style (built-in scenario or fresh AI prompt).</li>
@@ -595,7 +595,7 @@
       </ol>
     </section>
 
-    <section id="howto-video-coach" class="card">
+    <section id="homepage-video-coach" class="card">
       <h2>Video Coach</h2>
       <ol>
         <li>Choose the speech type you want to rehearse, then hit <em>Start Recording</em>.</li>
@@ -608,7 +608,7 @@
       </ol>
     </section>
 
-    <section id="howto-writing" class="card">
+    <section id="homepage-writing" class="card">
       <h2>Writing Lab</h2>
       <ol>
         <li>Pick a document type (opening, closing, cross, etc.) and jot down the facts or themes you want to highlight.</li>
@@ -618,7 +618,7 @@
       </ol>
     </section>
 
-    <section id="howto-rules" class="card">
+    <section id="homepage-rules" class="card">
       <h2>Rules Library</h2>
       <ol>
         <li>Search by rule number, keyword, or topic. Results update instantly.</li>
@@ -628,7 +628,7 @@
       </ol>
     </section>
 
-    <section id="howto-quiz" class="card">
+    <section id="homepage-quiz" class="card">
       <h2>Rules Quiz</h2>
       <ol>
         <li>Choose a mode (standard or lightning), the rule sets you want to review, question count, and difficulty.</li>
@@ -638,7 +638,7 @@
       </ol>
     </section>
 
-    <section id="howto-api" class="card">
+    <section id="homepage-api" class="card">
       <h2>OpenAI API Keys</h2>
       <ol>
         <li>Log in at <a href="https://platform.openai.com/">platform.openai.com</a> using your own account.</li>
@@ -656,7 +656,7 @@
     </main>
 
     <footer class="footer">
-      <p>Back to the <a href="index.html#howto">main How to section</a> or explore other tools from the <a href="index.html">home page</a>. Want rules at a glance? Jump into the <a href="rules.html" data-section="rules">Rules Library</a>, and when you're ready to practice live, start a <a href="video-coach.html" data-section="video">Video Coach</a> session.</p>
+      <p>Back to the <a href="index.html#homepage">main HomePage section</a> or explore other tools from the <a href="index.html">home page</a>. Want rules at a glance? Jump into the <a href="rules.html" data-section="rules">Rules Library</a>, and when you're ready to practice live, start a <a href="video-coach.html" data-section="video">Video Coach</a> session.</p>
     </footer>
   </div>
   <script>

--- a/index.html
+++ b/index.html
@@ -122,52 +122,52 @@ a.inline{color:var(--accent);text-decoration:underline}
 .coach-hidden{display:none!important}
 .title-block h1{color:#e2e8f0}
 .title-block .small,.title-block p{color:rgba(226,232,240,.9)}
-#howto.card{padding:0;background:transparent;border:none;box-shadow:none}
-#howto .page-shell{position:relative;width:min(1100px,92vw);margin:0 auto;padding:clamp(2.5rem,6vw,4rem) clamp(1.5rem,4vw,3rem) 3rem;display:flex;flex-direction:column;gap:clamp(2rem,5vw,3rem)}
-#howto .glow{position:absolute;inset:clamp(1rem,3vw,2.5rem);border-radius:28px;background:linear-gradient(135deg,rgba(56,189,248,.08),rgba(14,165,233,.03));border:1px solid rgba(148,163,184,.16);backdrop-filter:blur(22px);pointer-events:none}
-#howto .hero,#howto .content,#howto .footer{position:relative;z-index:1}
-#howto .hero{background:linear-gradient(135deg,rgba(56,189,248,.16),rgba(14,165,233,.08));border-radius:24px;padding:clamp(1.8rem,5vw,2.75rem);border:1px solid rgba(56,189,248,.25);box-shadow:0 25px 60px rgba(15,23,42,.4);display:flex;flex-direction:column;gap:1rem}
-#howto .hero h1,#howto .hero h2{margin:0;font-size:clamp(2.2rem,5vw,3rem);letter-spacing:-.02em}
-#howto .hero p{margin:0;color:var(--muted);max-width:60ch}
-#howto .hero p+p{font-size:.95rem;max-width:65ch;opacity:.9}
-#howto .eyebrow{font-size:.85rem;letter-spacing:.2em;text-transform:uppercase;color:#bae6fd;font-weight:600}
-#howto .anchor-nav ul{list-style:none;margin:0;padding:0;display:flex;flex-wrap:wrap;gap:.75rem}
-#howto .anchor-nav a{display:inline-flex;align-items:center;gap:.5rem;padding:.55rem .95rem;border-radius:999px;border:1px solid rgba(56,189,248,.35);background:rgba(15,23,42,.6);color:var(--text);text-decoration:none;font-size:.95rem;transition:transform .2s ease,box-shadow .2s ease,background .2s ease}
-#howto .anchor-nav a:hover,#howto .anchor-nav a:focus{transform:translateY(-2px);box-shadow:0 12px 30px rgba(56,189,248,.25);background:rgba(56,189,248,.2);outline:none}
-#howto .anchor-nav a.active{background:rgba(56,189,248,.32);box-shadow:0 16px 36px rgba(14,165,233,.24);color:#f0f9ff}
-#howto .section-chips{display:flex;flex-wrap:wrap;gap:.65rem;padding:.5rem 0 0}
-#howto .section-chip{position:relative;display:inline-flex;align-items:center;gap:.4rem;padding:.5rem .85rem;border-radius:14px;background:rgba(15,23,42,.72);border:1px solid rgba(148,163,184,.2);text-decoration:none;color:var(--muted);font-size:.85rem;transition:transform .2s ease,background .2s ease,border .2s ease}
-#howto .section-chip span{display:inline-flex;align-items:center;justify-content:center;width:1.45rem;height:1.45rem;border-radius:50%;background:rgba(56,189,248,.18);color:#bae6fd;font-size:.7rem;font-weight:600}
-#howto .section-chip.active{background:rgba(56,189,248,.3);border-color:rgba(56,189,248,.55);color:#f8fafc}
-#howto .section-chip:hover,#howto .section-chip:focus-visible{transform:translateY(-1px);background:rgba(56,189,248,.18);border-color:rgba(56,189,248,.45);color:#f8fafc;outline:none}
-#howto .content{display:grid;gap:clamp(1.5rem,4vw,2.5rem)}
-#howto .content>.card{display:block;background:rgba(15,23,42,.88);border-radius:22px;padding:clamp(1.6rem,4vw,2.4rem);border:1px solid rgba(148,163,184,.18);box-shadow:0 25px 60px rgba(15,23,42,.4);position:relative;overflow:hidden}
-#howto .content>.card h2{margin-top:0;font-size:clamp(1.45rem,3vw,1.85rem);letter-spacing:-.01em;display:inline-flex;align-items:center;gap:.55rem}
-#howto .content>.card h2::before{content:"";width:10px;height:10px;border-radius:999px;background:var(--accent);box-shadow:0 0 12px rgba(56,189,248,.6)}
-#howto .content>.card::after{content:"";position:absolute;inset:0;background:radial-gradient(120% 140% at 100% 0%,rgba(56,189,248,.18),transparent 55%);opacity:0;transition:opacity .3s ease;pointer-events:none}
-#howto .content>.card:hover::after,#howto .content>.card:focus-within::after{opacity:1}
-#howto .content>.card p,#howto .content>.card ol{color:var(--muted)}
-#howto .content>.card ol{margin:0;padding-left:1.1rem;display:grid;gap:.75rem}
-#howto .content>.card li{line-height:1.6}
-#howto .content>.card.highlight{background:linear-gradient(135deg,rgba(56,189,248,.14),rgba(37,99,235,.22));border:1px solid rgba(56,189,248,.45)}
-#howto .info-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1.15rem;margin-top:1.35rem}
-#howto .info-tile{border-radius:18px;border:1px solid rgba(125,211,252,.35);background:rgba(8,47,73,.4);padding:1.2rem 1.35rem;display:flex;flex-direction:column;gap:.85rem;min-height:100%;transition:transform .2s ease,box-shadow .2s ease,border .2s ease}
-#howto .info-tile:hover,#howto .info-tile:focus-within{transform:translateY(-4px);box-shadow:0 20px 46px rgba(14,165,233,.32);border-color:rgba(56,189,248,.55)}
-#howto .info-header{display:flex;justify-content:space-between;align-items:center;gap:.75rem}
-#howto .info-header strong{font-size:1.05rem;color:var(--text);letter-spacing:-.01em}
-#howto .info-summary{color:rgba(226,232,240,.8);font-size:.9rem;line-height:1.5;margin:0}
-#howto .info-actions{display:flex;flex-wrap:wrap;gap:.6rem}
-#howto .info-link{display:inline-flex;align-items:center;gap:.35rem;padding:.45rem .85rem;border-radius:999px;text-decoration:none;font-size:.85rem;font-weight:500;transition:background .2s ease,color .2s ease}
-#howto .info-link svg{width:.85rem;height:.85rem}
-#howto .info-link--howto{background:rgba(56,189,248,.18);color:#e0f2fe;border:1px solid rgba(56,189,248,.4)}
-#howto .info-link--howto:hover,#howto .info-link--howto:focus-visible{background:rgba(56,189,248,.3);color:#f8fafc;outline:none}
-#howto .info-link--launch{background:rgba(15,23,42,.7);color:rgba(191,219,254,.9);border:1px solid rgba(148,163,184,.3)}
-#howto .info-link--launch:hover,#howto .info-link--launch:focus-visible{background:rgba(15,23,42,.92);color:#f8fafc;border-color:rgba(191,219,254,.6);outline:none}
-#howto .callout{border-radius:18px;border:1px dashed rgba(125,211,252,.4);background:rgba(15,118,110,.18);padding:1.1rem 1.3rem;color:#ccfbf1;font-size:.95rem;display:grid;gap:.4rem}
-#howto .callout strong{color:#5eead4;text-transform:uppercase;letter-spacing:.1em;font-size:.75rem}
-#howto .footer{text-align:center;color:var(--muted);font-size:.95rem}
-#howto .footer a{font-weight:600}
-@media(max-width:640px){#howto .page-shell{padding:1.75rem 1.1rem 2.5rem}#howto .content>.card{padding:1.5rem}#howto .info-header{flex-direction:column;align-items:flex-start}#howto .info-actions{width:100%}#howto .info-link{width:fit-content}}
+#homepage.card{padding:0;background:transparent;border:none;box-shadow:none}
+#homepage .page-shell{position:relative;width:min(1100px,92vw);margin:0 auto;padding:clamp(2.5rem,6vw,4rem) clamp(1.5rem,4vw,3rem) 3rem;display:flex;flex-direction:column;gap:clamp(2rem,5vw,3rem)}
+#homepage .glow{position:absolute;inset:clamp(1rem,3vw,2.5rem);border-radius:28px;background:linear-gradient(135deg,rgba(56,189,248,.08),rgba(14,165,233,.03));border:1px solid rgba(148,163,184,.16);backdrop-filter:blur(22px);pointer-events:none}
+#homepage .hero,#homepage .content,#homepage .footer{position:relative;z-index:1}
+#homepage .hero{background:linear-gradient(135deg,rgba(56,189,248,.16),rgba(14,165,233,.08));border-radius:24px;padding:clamp(1.8rem,5vw,2.75rem);border:1px solid rgba(56,189,248,.25);box-shadow:0 25px 60px rgba(15,23,42,.4);display:flex;flex-direction:column;gap:1rem}
+#homepage .hero h1,#homepage .hero h2{margin:0;font-size:clamp(2.2rem,5vw,3rem);letter-spacing:-.02em}
+#homepage .hero p{margin:0;color:var(--muted);max-width:60ch}
+#homepage .hero p+p{font-size:.95rem;max-width:65ch;opacity:.9}
+#homepage .eyebrow{font-size:.85rem;letter-spacing:.2em;text-transform:uppercase;color:#bae6fd;font-weight:600}
+#homepage .anchor-nav ul{list-style:none;margin:0;padding:0;display:flex;flex-wrap:wrap;gap:.75rem}
+#homepage .anchor-nav a{display:inline-flex;align-items:center;gap:.5rem;padding:.55rem .95rem;border-radius:999px;border:1px solid rgba(56,189,248,.35);background:rgba(15,23,42,.6);color:var(--text);text-decoration:none;font-size:.95rem;transition:transform .2s ease,box-shadow .2s ease,background .2s ease}
+#homepage .anchor-nav a:hover,#homepage .anchor-nav a:focus{transform:translateY(-2px);box-shadow:0 12px 30px rgba(56,189,248,.25);background:rgba(56,189,248,.2);outline:none}
+#homepage .anchor-nav a.active{background:rgba(56,189,248,.32);box-shadow:0 16px 36px rgba(14,165,233,.24);color:#f0f9ff}
+#homepage .section-chips{display:flex;flex-wrap:wrap;gap:.65rem;padding:.5rem 0 0}
+#homepage .section-chip{position:relative;display:inline-flex;align-items:center;gap:.4rem;padding:.5rem .85rem;border-radius:14px;background:rgba(15,23,42,.72);border:1px solid rgba(148,163,184,.2);text-decoration:none;color:var(--muted);font-size:.85rem;transition:transform .2s ease,background .2s ease,border .2s ease}
+#homepage .section-chip span{display:inline-flex;align-items:center;justify-content:center;width:1.45rem;height:1.45rem;border-radius:50%;background:rgba(56,189,248,.18);color:#bae6fd;font-size:.7rem;font-weight:600}
+#homepage .section-chip.active{background:rgba(56,189,248,.3);border-color:rgba(56,189,248,.55);color:#f8fafc}
+#homepage .section-chip:hover,#homepage .section-chip:focus-visible{transform:translateY(-1px);background:rgba(56,189,248,.18);border-color:rgba(56,189,248,.45);color:#f8fafc;outline:none}
+#homepage .content{display:grid;gap:clamp(1.5rem,4vw,2.5rem)}
+#homepage .content>.card{display:block;background:rgba(15,23,42,.88);border-radius:22px;padding:clamp(1.6rem,4vw,2.4rem);border:1px solid rgba(148,163,184,.18);box-shadow:0 25px 60px rgba(15,23,42,.4);position:relative;overflow:hidden}
+#homepage .content>.card h2{margin-top:0;font-size:clamp(1.45rem,3vw,1.85rem);letter-spacing:-.01em;display:inline-flex;align-items:center;gap:.55rem}
+#homepage .content>.card h2::before{content:"";width:10px;height:10px;border-radius:999px;background:var(--accent);box-shadow:0 0 12px rgba(56,189,248,.6)}
+#homepage .content>.card::after{content:"";position:absolute;inset:0;background:radial-gradient(120% 140% at 100% 0%,rgba(56,189,248,.18),transparent 55%);opacity:0;transition:opacity .3s ease;pointer-events:none}
+#homepage .content>.card:hover::after,#homepage .content>.card:focus-within::after{opacity:1}
+#homepage .content>.card p,#homepage .content>.card ol{color:var(--muted)}
+#homepage .content>.card ol{margin:0;padding-left:1.1rem;display:grid;gap:.75rem}
+#homepage .content>.card li{line-height:1.6}
+#homepage .content>.card.highlight{background:linear-gradient(135deg,rgba(56,189,248,.14),rgba(37,99,235,.22));border:1px solid rgba(56,189,248,.45)}
+#homepage .info-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1.15rem;margin-top:1.35rem}
+#homepage .info-tile{border-radius:18px;border:1px solid rgba(125,211,252,.35);background:rgba(8,47,73,.4);padding:1.2rem 1.35rem;display:flex;flex-direction:column;gap:.85rem;min-height:100%;transition:transform .2s ease,box-shadow .2s ease,border .2s ease}
+#homepage .info-tile:hover,#homepage .info-tile:focus-within{transform:translateY(-4px);box-shadow:0 20px 46px rgba(14,165,233,.32);border-color:rgba(56,189,248,.55)}
+#homepage .info-header{display:flex;justify-content:space-between;align-items:center;gap:.75rem}
+#homepage .info-header strong{font-size:1.05rem;color:var(--text);letter-spacing:-.01em}
+#homepage .info-summary{color:rgba(226,232,240,.8);font-size:.9rem;line-height:1.5;margin:0}
+#homepage .info-actions{display:flex;flex-wrap:wrap;gap:.6rem}
+#homepage .info-link{display:inline-flex;align-items:center;gap:.35rem;padding:.45rem .85rem;border-radius:999px;text-decoration:none;font-size:.85rem;font-weight:500;transition:background .2s ease,color .2s ease}
+#homepage .info-link svg{width:.85rem;height:.85rem}
+#homepage .info-link--homepage{background:rgba(56,189,248,.18);color:#e0f2fe;border:1px solid rgba(56,189,248,.4)}
+#homepage .info-link--homepage:hover,#homepage .info-link--homepage:focus-visible{background:rgba(56,189,248,.3);color:#f8fafc;outline:none}
+#homepage .info-link--launch{background:rgba(15,23,42,.7);color:rgba(191,219,254,.9);border:1px solid rgba(148,163,184,.3)}
+#homepage .info-link--launch:hover,#homepage .info-link--launch:focus-visible{background:rgba(15,23,42,.92);color:#f8fafc;border-color:rgba(191,219,254,.6);outline:none}
+#homepage .callout{border-radius:18px;border:1px dashed rgba(125,211,252,.4);background:rgba(15,118,110,.18);padding:1.1rem 1.3rem;color:#ccfbf1;font-size:.95rem;display:grid;gap:.4rem}
+#homepage .callout strong{color:#5eead4;text-transform:uppercase;letter-spacing:.1em;font-size:.75rem}
+#homepage .footer{text-align:center;color:var(--muted);font-size:.95rem}
+#homepage .footer a{font-weight:600}
+@media(max-width:640px){#homepage .page-shell{padding:1.75rem 1.1rem 2.5rem}#homepage .content>.card{padding:1.5rem}#homepage .info-header{flex-direction:column;align-items:flex-start}#homepage .info-actions{width:100%}#homepage .info-link{width:fit-content}}
 </style>
 </head>
 <body>
@@ -195,7 +195,7 @@ a.inline{color:var(--accent);text-decoration:underline}
     <a class="tab" href="#rules" id="rulesTab">AZ Rules</a>
     <a class="tab" href="#quiz">Rules Quiz</a>
     <a class="tab" href="#keys">API Keys</a>
-    <a class="tab" href="#howto">How To Use</a>
+    <a class="tab" href="#homepage">HomePage</a>
     <a class="tab" href="#contact">Contact</a>
   </nav>
 
@@ -436,26 +436,26 @@ a.inline{color:var(--accent);text-decoration:underline}
       </div>
     </div>
   </section>
-  <!-- How To -->
-  <section id="howto" class="card howto-host">
+  <!-- HomePage -->
+  <section id="homepage" class="card homepage-host">
     <div class="page-shell">
       <div class="glow" aria-hidden="true"></div>
       <header class="hero">
-        <h2>How to Use MT Academy</h2>
+        <h2>HomePage</h2>
       </header>
 
       <div class="content">
-        <section id="howto-overview" class="card highlight">
+        <section id="homepage-overview" class="card highlight">
           <h2>Quick Start</h2>
           <p>Decide what skill you want to sharpen, then launch the matching tool. You can move between apps freely—your progress and generated drafts stay in their tabs until you clear them.</p>
-          <p>If you plan to use ChatGPT scoring, drafting, or movement analysis, create your own OpenAI API key before jumping into drills (see <a href="#howto-api">API Keys</a> below). Each tile includes a shortcut to its how-to section and a direct launch link.</p>
+          <p>If you plan to use ChatGPT scoring, drafting, or movement analysis, create your own OpenAI API key before jumping into drills (see <a href="#homepage-api">API Keys</a> below). Each tile includes a shortcut to its detailed section and a direct launch link.</p>
           <div class="info-grid" aria-label="Tool shortcuts">
             <article class="info-tile">
               <div class="info-header">
                 <strong>Objections Drill</strong>
-                <a class="info-link info-link--howto" href="#howto-objections" aria-label="Read how to use the Objections Drill">
+                <a class="info-link info-link--homepage" href="#homepage-objections" aria-label="Read about the Objections Drill">
                   <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
-                  How-to
+                  HomePage
                 </a>
               </div>
               <p class="info-summary">Practice fast objections with built-in fact patterns or AI-generated prompts.</p>
@@ -466,9 +466,9 @@ a.inline{color:var(--accent);text-decoration:underline}
             <article class="info-tile">
               <div class="info-header">
                 <strong>Video Coach</strong>
-                <a class="info-link info-link--howto" href="#howto-video-coach" aria-label="Read how to use the Video Coach">
+                <a class="info-link info-link--homepage" href="#homepage-video-coach" aria-label="Read about the Video Coach">
                   <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
-                  How-to
+                  HomePage
                 </a>
               </div>
               <p class="info-summary">Record and score speeches with movement analysis plus delivery feedback.</p>
@@ -479,9 +479,9 @@ a.inline{color:var(--accent);text-decoration:underline}
             <article class="info-tile">
               <div class="info-header">
                 <strong>Writing Lab</strong>
-                <a class="info-link info-link--howto" href="#howto-writing" aria-label="Read how to use the Writing Lab">
+                <a class="info-link info-link--homepage" href="#homepage-writing" aria-label="Read about the Writing Lab">
                   <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
-                  How-to
+                  HomePage
                 </a>
               </div>
               <p class="info-summary">Draft openings, closings, and crosses using your notes and ChatGPT assists.</p>
@@ -492,9 +492,9 @@ a.inline{color:var(--accent);text-decoration:underline}
             <article class="info-tile">
               <div class="info-header">
                 <strong>Rules Library</strong>
-                <a class="info-link info-link--howto" href="#howto-rules" aria-label="Read how to use the Rules Library">
+                <a class="info-link info-link--homepage" href="#homepage-rules" aria-label="Read about the Rules Library">
                   <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
-                  How-to
+                  HomePage
                 </a>
               </div>
               <p class="info-summary">Search the NCHSAA rules instantly and save citations for competition.</p>
@@ -505,9 +505,9 @@ a.inline{color:var(--accent);text-decoration:underline}
             <article class="info-tile">
               <div class="info-header">
                 <strong>Rules Quiz</strong>
-                <a class="info-link info-link--howto" href="#howto-quiz" aria-label="Read how to use the Rules Quiz">
+                <a class="info-link info-link--homepage" href="#homepage-quiz" aria-label="Read about the Rules Quiz">
                   <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
-                  How-to
+                  HomePage
                 </a>
               </div>
               <p class="info-summary">Challenge yourself or teammates with custom quizzes and lightning rounds.</p>
@@ -518,9 +518,9 @@ a.inline{color:var(--accent);text-decoration:underline}
             <article class="info-tile">
               <div class="info-header">
                 <strong>API Keys Portal</strong>
-                <a class="info-link info-link--howto" href="#howto-api" aria-label="Read how to set up API keys">
+                <a class="info-link info-link--homepage" href="#homepage-api" aria-label="Read about setting up API keys">
                   <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor"><path d="M3 8a.75.75 0 0 1 .75-.75h6.69L8.22 5.03a.75.75 0 1 1 1.06-1.06l3.5 3.5a.75.75 0 0 1 0 1.06l-3.5 3.5a.75.75 0 1 1-1.06-1.06l2.22-2.22H3.75A.75.75 0 0 1 3 8Z"/></svg>
-                  How-to
+                  HomePage
                 </a>
               </div>
               <p class="info-summary">Securely store, test, or remove the OpenAI keys used across every tool.</p>
@@ -531,7 +531,7 @@ a.inline{color:var(--accent);text-decoration:underline}
           </div>
         </section>
 
-        <section id="howto-objections" class="card">
+        <section id="homepage-objections" class="card">
           <h2>Objections Drill</h2>
           <ol>
             <li>Set the topic, difficulty, and prompt style (built-in scenario or fresh AI prompt).</li>
@@ -543,7 +543,7 @@ a.inline{color:var(--accent);text-decoration:underline}
           </ol>
         </section>
 
-        <section id="howto-video-coach" class="card">
+        <section id="homepage-video-coach" class="card">
           <h2>Video Coach</h2>
           <ol>
             <li>Choose the speech type you want to rehearse, then hit <em>Start Recording</em>.</li>
@@ -556,7 +556,7 @@ a.inline{color:var(--accent);text-decoration:underline}
           </ol>
         </section>
 
-        <section id="howto-writing" class="card">
+        <section id="homepage-writing" class="card">
           <h2>Writing Lab</h2>
           <ol>
             <li>Pick a document type (opening, closing, cross, etc.) and jot down the facts or themes you want to highlight.</li>
@@ -566,7 +566,7 @@ a.inline{color:var(--accent);text-decoration:underline}
           </ol>
         </section>
 
-        <section id="howto-rules" class="card">
+        <section id="homepage-rules" class="card">
           <h2>Rules Library</h2>
           <ol>
             <li>Search by rule number, keyword, or topic. Results update instantly.</li>
@@ -576,7 +576,7 @@ a.inline{color:var(--accent);text-decoration:underline}
           </ol>
         </section>
 
-        <section id="howto-quiz" class="card">
+        <section id="homepage-quiz" class="card">
           <h2>Rules Quiz</h2>
           <ol>
             <li>Choose a mode (standard or lightning), the rule sets you want to review, question count, and difficulty.</li>
@@ -586,7 +586,7 @@ a.inline{color:var(--accent);text-decoration:underline}
           </ol>
         </section>
 
-        <section id="howto-api" class="card">
+        <section id="homepage-api" class="card">
           <h2>OpenAI API Keys</h2>
           <ol>
             <li>Log in at <a href="https://platform.openai.com/">platform.openai.com</a> using your own account.</li>
@@ -604,7 +604,7 @@ a.inline{color:var(--accent);text-decoration:underline}
       </div>
 
       <footer class="footer">
-        <p>Back to the <a href="#howto-overview">top of this guide</a> or explore other tools from the main navigation. Want rules at a glance? Jump into the <a href="rules.html" data-section="rules">Rules Library</a>, and when you're ready to practice live, start a <a href="video-coach.html" data-section="video">Video Coach</a> session.</p>
+        <p>Back to the <a href="#homepage-overview">top of this guide</a> or explore other tools from the main navigation. Want rules at a glance? Jump into the <a href="rules.html" data-section="rules">Rules Library</a>, and when you're ready to practice live, start a <a href="video-coach.html" data-section="video">Video Coach</a> session.</p>
       </footer>
     </div>
   </section>
@@ -4682,16 +4682,16 @@ document.addEventListener('DOMContentLoaded',()=>{
     if(id==='video'){ maybeShowVideoGate(); }
   }
 
-  function initHowTo(initialHash){
-    const howto=$('howto');
-    if(!howto) return;
-    const navLinks=Array.from(howto.querySelectorAll('.anchor-nav a'));
-    const chipLinks=Array.from(howto.querySelectorAll('.section-chips a'));
+  function initHomePage(initialHash){
+    const homepage=$('homepage');
+    if(!homepage) return;
+    const navLinks=Array.from(homepage.querySelectorAll('.anchor-nav a'));
+    const chipLinks=Array.from(homepage.querySelectorAll('.section-chips a'));
     const observeSections=navLinks
       .map(link=>{
         const href=link.getAttribute('href');
         if(!href || !href.startsWith('#')) return null;
-        return howto.querySelector(href);
+        return homepage.querySelector(href);
       })
       .filter(Boolean);
 
@@ -4716,11 +4716,11 @@ document.addEventListener('DOMContentLoaded',()=>{
       observeSections.forEach(section=>observer.observe(section));
     }
 
-    howto.querySelectorAll('a[href^="#howto-"]').forEach(link=>{
+    homepage.querySelectorAll('a[href^="#homepage-"]').forEach(link=>{
       link.addEventListener('click',evt=>{
         const href=link.getAttribute('href');
         if(!href) return;
-        const target=howto.querySelector(href);
+        const target=homepage.querySelector(href);
         if(target){
           evt.preventDefault();
           target.scrollIntoView({behavior:'smooth',block:'start'});
@@ -4729,7 +4729,7 @@ document.addEventListener('DOMContentLoaded',()=>{
       });
     });
 
-    howto.querySelectorAll('a[data-section]').forEach(link=>{
+    homepage.querySelectorAll('a[data-section]').forEach(link=>{
       link.addEventListener('click',evt=>{
         const target=link.getAttribute('data-section');
         if(target){
@@ -4739,8 +4739,8 @@ document.addEventListener('DOMContentLoaded',()=>{
       });
     });
 
-    if(initialHash && initialHash.startsWith('howto-')){
-      const target=howto.querySelector(`#${initialHash}`);
+    if(initialHash && initialHash.startsWith('homepage-')){
+      const target=homepage.querySelector(`#${initialHash}`);
       if(target){
         target.scrollIntoView({behavior:'auto',block:'start'});
         activate(initialHash);
@@ -4761,9 +4761,9 @@ document.addEventListener('DOMContentLoaded',()=>{
 
   const topLevelIds=sections.map(sec=>sec.id);
   const rawHash=location.hash.slice(1);
-  const initialHash=topLevelIds.includes(rawHash)?rawHash:'howto';
+  const initialHash=topLevelIds.includes(rawHash)?rawHash:'homepage';
   showSection(initialHash);
-  initHowTo(rawHash);
+  initHomePage(rawHash);
 
   document.querySelectorAll('a.hidden-link').forEach(link=>{
     link.addEventListener('click',e=>{

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -19,7 +19,7 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://mocktrialacademy.com/howto.html</loc>
+    <loc>https://mocktrialacademy.com/homepage.html</loc>
     <lastmod>2025-10-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>


### PR DESCRIPTION
## Summary
- rename the standalone How-To page to `homepage.html` and update its metadata and copy to use the new HomePage name
- update the index navigation, section anchors, and supporting script logic to reference the HomePage naming
- refresh the sitemap entry to point at the renamed HomePage URL

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e5ce0fb2cc8331a8f85f043c468ac3